### PR TITLE
fix: table color dark mode

### DIFF
--- a/website/components/ui/Markdown.tsx
+++ b/website/components/ui/Markdown.tsx
@@ -64,6 +64,9 @@ const DEFAULT_COMPONENTS: MarkdownProps['components'] = {
   h2({ node, children, ...props }) {
     return <H2 {...props}>{children}</H2>
   },
+  table({ node, className, children, ...props }) {
+    return <table className={cn('dark:text-white', className)} {...props}>{children}</table>
+  }
 }
 
 const COPYABLE_CODE_COMPONENTS: MarkdownProps['components'] = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed the color of the table in dark mode

## What is the current behavior?

Closes #47

## What is the new behavior?
![overlap-resolved](https://user-images.githubusercontent.com/38078427/232195711-a5c805cf-15ee-4a04-a5ec-a9615a7de0a7.png)

## Additional context
Before
![overlap](https://user-images.githubusercontent.com/38078427/232195706-a34c0989-cefb-4b0d-aa66-dc9258c995bb.png)
