### PR TITLE
fix: small ui issues

### DIFF
--- a/website/components/ui/Markdown.tsx
+++ b/website/components/ui/Markdown.tsx
@@ -64,8 +64,11 @@ const DEFAULT_COMPONENTS: MarkdownProps['components'] = {
   h2({ node, children, ...props }) {
     return <H2 {...props}>{children}</H2>
   },
-  table({ node, className, children, ...props }) {
-    return <table className={cn('dark:text-white', className)} {...props}>{children}</table>
+  th({ node, className, children, ...props }) {
+    return <th className={cn('font-semibold dark:text-white', className)} {...props}>{children}</th>
+  },
+  td({ node, className, children, ...props }) {
+    return <td className={cn('dark:text-white', className)} {...props}>{children}</td>
   }
 }
 

--- a/website/components/ui/typography/A.tsx
+++ b/website/components/ui/typography/A.tsx
@@ -1,11 +1,11 @@
 import { ComponentPropsWithoutRef, forwardRef } from 'react'
 import { cn } from '~/lib/utils'
 
-export interface AProps extends ComponentPropsWithoutRef<'a'> {}
+export interface AProps extends ComponentPropsWithoutRef<'a'> { }
 
 const A = forwardRef<HTMLAnchorElement, AProps>(
   ({ className, children, ...props }) => (
-    <a className={cn('tracking-tight dark:text-white', className)} {...props}>
+    <a className={cn('tracking-tight dark:text-white line-break', className)} {...props}>
       {children}
     </a>
   )

--- a/website/styles/globals.css
+++ b/website/styles/globals.css
@@ -9,3 +9,7 @@ body,
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
 }
+
+.line-break {
+  line-break: anywhere;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed the UI Issues on small devices. When there is a link in the markdown, the page layout shifts and it shows some white spaces. Also added the dark mode color to header of the table.

## What is the current behavior?

![overlap](https://user-images.githubusercontent.com/38078427/232216778-3b64f6f6-49ed-4705-bc79-f74dca525f86.png)
## What is the new behavior?

![overlap-resolved](https://user-images.githubusercontent.com/38078427/232216788-420be2c1-0db4-4e82-b0a1-f715cdf0e752.png)


## Additional context

