### PR TITLE
fix long names pushing version out of the box

### DIFF
--- a/website/components/packages/PackageCard.tsx
+++ b/website/components/packages/PackageCard.tsx
@@ -26,7 +26,7 @@ const PackageCard = ({ pkg, className }: PackageCardProps) => {
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-1">
-          <p className="font-medium dark:text-white">{pkg.partial_name} </p>
+          <p className="font-medium dark:text-white overflow-hidden truncate w-36">{pkg.partial_name} </p>
 
           <p className="font-normal text-gray-400">•</p>
           <p className="font-normal text-gray-400">{pkg.latest_version}</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

This PR fixes the [bug in which long names pushed the version out of the parent content box](https://github.com/supabase/dbdev/issues/53)

## What is the new behavior?

If a package has a long name then the text will be truncated with ellipsis at the end. Inspiration for this was taken from crates.io where similar behaviour exists. Ideas to improve the UX further would be to show a tooltip for truncated names but this is not implemented yet. For now the user can click the box to see the full name on the package's page. This is how it looks now:

![Supabase](https://github.com/supabase/dbdev/assets/1666073/f055c425-cabf-4f28-ae6e-b88dbbe03c9d)

## Additional context

N/A
