### PR TITLE
fix invisible h3 headers in dark mode

### DIFF
--- a/website/components/ui/Markdown.tsx
+++ b/website/components/ui/Markdown.tsx
@@ -7,6 +7,7 @@ import CopyButton from './CopyButton'
 import A from './typography/A'
 import H1 from './typography/H1'
 import H2 from './typography/H2'
+import H3 from './typography/H3'
 import Li from './typography/Li'
 import P from './typography/P'
 import Strong from './typography/Strong'
@@ -63,6 +64,9 @@ const DEFAULT_COMPONENTS: MarkdownProps['components'] = {
   },
   h2({ node, children, ...props }) {
     return <H2 {...props}>{children}</H2>
+  },
+  h3({ node, children, ...props }) {
+    return <H3 {...props}>{children}</H3>
   },
   th({ node, className, children, ...props }) {
     return <th className={cn('font-semibold dark:text-white', className)} {...props}>{children}</th>

--- a/website/components/ui/typography/H3.tsx
+++ b/website/components/ui/typography/H3.tsx
@@ -1,0 +1,23 @@
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
+import { cn } from '~/lib/utils'
+
+export interface H3Props extends ComponentPropsWithoutRef<'h1'> {}
+
+const H3 = forwardRef<HTMLHeadingElement, H3Props>(
+  ({ className, children, ...props }, ref) => (
+    <h3
+      className={cn(
+        'scroll-m-20 text-1xl font-semibold tracking-tight transition-colors first:mt-0 dark:border-b-slate-700 dark:text-white',
+        className
+      )}
+      {...props}
+      ref={ref}
+    >
+      {children}
+    </h3>
+  )
+)
+
+H3.displayName = 'H3'
+
+export default H3


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes https://github.com/supabase/dbdev/issues/62

## What is the new behavior?

h3 headers are now visible in dark mode:

![supabase_h3](https://github.com/supabase/dbdev/assets/1666073/6b97bbdb-88d1-4e6d-b903-6f6de7ce4a42)


## Additional context

h4, h5 and h6 headers have not been tested. They probably are also not visible in dark mode but I couldn't test as I couldn't (yet) find a way to insert data into the db.
