### PR TITLE
fix incorrect error message

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -70,7 +70,7 @@ impl APIClient {
             }))
             .send()
             .await
-            .context("failed to create user")?;
+            .context("failed to get access token")?;
 
         if response.status() != 200 {
             return Err(anyhow::anyhow!(response.text().await?));


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Incorrect error context was set for the `get_access_token` method.

## What is the new behavior?

Corrected the context string.

## Additional context

N/A
