### PR TITLE
Fix error if display name is missing

### DIFF
--- a/website/components/layouts/Navbar.tsx
+++ b/website/components/layouts/Navbar.tsx
@@ -42,6 +42,9 @@ const Navbar = () => {
     user?.user_metadata.handle ??
     'Current User'
 
+  const displayName: string =
+    user?.user_metadata.display_name ?? user?.email ?? 'Account'
+
   const avatarFallback = avatarName
     .split(' ')
     .map((n) => n[0])
@@ -60,13 +63,10 @@ const Navbar = () => {
     })
   }, [router, signOut])
 
-  const AvatarWrapper = ({ size = 'sm' }: { size?: 'sm' | 'md' }) => {
-    const display_name = user?.user_metadata.display_name
-      ? user?.user_metadata.display_name
-      : user?.email
-    return user?.user_metadata.avatar_path === undefined ? (
+  const AvatarWrapper = ({ size = 'sm' }: { size?: 'sm' | 'md' }) =>
+    user?.user_metadata.avatar_path === undefined ? (
       <div className="flex items-center justify-center w-6 h-6 text-gray-600 bg-gray-300 border-gray-400 rounded-full border-1 dark:border-slate-400 dark:bg-slate-500 dark:text-white">
-        {display_name[0].toUpperCase()}
+        {displayName[0].toUpperCase()}
       </div>
     ) : (
       <Avatar size={size} className="border dark:border-slate-700">
@@ -74,7 +74,6 @@ const Navbar = () => {
         <AvatarFallback>{avatarFallback}</AvatarFallback>
       </Avatar>
     )
-  }
 
   return (
     <header className="px-4 py-4 border-b border-gray-100 shadow-sm dark:border-slate-700 md:px-8">
@@ -113,9 +112,7 @@ const Navbar = () => {
                       href={`/${user?.user_metadata.handle}`}
                       className="flex items-center cursor-pointer"
                     >
-                      {user?.user_metadata.display_name ??
-                        user?.email ??
-                        'Account'}
+                      {displayName}
                     </Link>
                   </DropdownMenuItem>
 

--- a/website/components/layouts/Navbar.tsx
+++ b/website/components/layouts/Navbar.tsx
@@ -60,10 +60,13 @@ const Navbar = () => {
     })
   }, [router, signOut])
 
-  const AvatarWrapper = ({ size = 'sm' }: { size?: 'sm' | 'md' }) =>
-    user?.user_metadata.avatar_path === undefined ? (
+  const AvatarWrapper = ({ size = 'sm' }: { size?: 'sm' | 'md' }) => {
+    const display_name = user?.user_metadata.display_name
+      ? user?.user_metadata.display_name
+      : user?.email
+    return user?.user_metadata.avatar_path === undefined ? (
       <div className="flex items-center justify-center w-6 h-6 text-gray-600 bg-gray-300 border-gray-400 rounded-full border-1 dark:border-slate-400 dark:bg-slate-500 dark:text-white">
-        {user?.user_metadata.display_name[0].toUpperCase()}
+        {display_name[0].toUpperCase()}
       </div>
     ) : (
       <Avatar size={size} className="border dark:border-slate-700">
@@ -71,6 +74,7 @@ const Navbar = () => {
         <AvatarFallback>{avatarFallback}</AvatarFallback>
       </Avatar>
     )
+  }
 
   return (
     <header className="px-4 py-4 border-b border-gray-100 shadow-sm dark:border-slate-700 md:px-8">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If a user doesn't have a display name an error occurs in the UI when they login. The error is in the code which tries to show the navbar character.

## What is the new behavior?

If the display name is missing the UI falls back to the first character of the email.

## Additional context

In case you are wondering the error occurs while displaying the `R` in the top right:

<img width="1263" alt="image" src="https://github.com/supabase/dbdev/assets/1666073/ce88a66e-ce13-4cfc-83dd-c376c05d46a0">

The way to have no display name is to use the current CLI with the command `cargo run signup` which doesn't take a display name.