### PR TITLE
remove unnecessary calls to `collect`

### DIFF
--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -218,12 +218,8 @@ impl ControlFileRef {
         for line in self.contents.lines() {
             if line.starts_with("requires") {
                 let value = self.read_control_line_value(line)?;
-                let required_packages: Vec<String> = value
-                    .split(',')
-                    .collect::<Vec<&str>>()
-                    .iter()
-                    .map(|x| x.trim().to_string())
-                    .collect();
+                let required_packages: Vec<String> =
+                    value.split(',').map(|x| x.trim().to_string()).collect();
                 return Ok(Some(required_packages));
             }
         }


### PR DESCRIPTION
Don't need to call `collect` and then `iter`. The `split` method already returns an iterable.