### PR TITLE
Make package views security invokers

### DIFF
--- a/supabase/migrations/20230831172915_allow_anon_access_to_package_views.sql
+++ b/supabase/migrations/20230831172915_allow_anon_access_to_package_views.sql
@@ -1,0 +1,3 @@
+alter view public.packages set (security_invoker=false);
+alter view public.package_versions set (security_invoker=false);
+alter view public.package_upgrades set (security_invoker=false);


### PR DESCRIPTION
## What kind of change does this PR introduce?
Reverts https://github.com/supabase/dbdev/pull/89 on the `public.package*` views.

Currently, there are no RLS policies for the `anon` role on `app.package*` tables so when these views take on the permissions of the underlying tables, no packages are visible to unauthenticated clients.

This was originally not noticed because it isn't visible when logged in on `database.dev`.

Unauthenticated users see a blank home page (see screenshot) and are currently unable to pull from the registry using the `supabase-dbdev` in-database client, instead seeing an error 

```
Failed to run sql query: "version" is a required argument
```

This PR re-enables the homepage to populate for `anon` users and re-enables the database client.

A better solution (for a later time) will be to create policies for the `anon` role and re-apply `security_invoker=false` to the views 


---

<img width="1242" alt="Screenshot 2023-08-31 at 12 24 41 PM" src="https://github.com/supabase/dbdev/assets/12958657/3099dac8-e582-4f76-b349-66e1011d050d">
