### PR TITLE
fix uninstall command

### DIFF
--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -1,7 +1,20 @@
 use anyhow::Context;
 use sqlx::postgres::PgConnection;
+use sqlx::Row;
 
 pub async fn uninstall(extension_name: &str, mut conn: PgConnection) -> anyhow::Result<()> {
+    let quoted_extension_name: String = sqlx::query("select quote_ident($1) as ident")
+        .bind(extension_name)
+        .map(|row| row.get("ident"))
+        .fetch_one(&mut conn)
+        .await
+        .context("Failed to get quoted identifier")?;
+
+    sqlx::query(&format!("drop extension if exists {quoted_extension_name}"))
+        .execute(&mut conn)
+        .await
+        .context(format!("failed to drop extension {}", extension_name))?;
+
     sqlx::query("select 1 from pgtle.uninstall_extension($1)")
         .bind(extension_name)
         .execute(&mut conn)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`dbdev uninstall` command did not uninstall an install TLE.

## What is the new behavior?

`dbdev uninstall` command successfully uninstalls the TLE.

## Additional context

The CLI did not run a required step of `drop extension ...` due to which the uninstallation was failing.