### PR TITLE
Add action to release `dbdev` CLI

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -1,14 +1,9 @@
 name: Release CLI
 
-# on:
-#   push:
-#     tags:
-#       - 'v*'
 on:
   push:
-    branches: ["feat/release-cli"]
-  pull_request:
-    branches: ["feat/release-cli"]
+    tags:
+      - 'v*'
 
 jobs:
   release:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -43,8 +43,8 @@ jobs:
         run: cargo build --release --verbose
         working-directory: ./cli
 
-       name: Tarball
-       run: cd ./cli/target/release && tar -czvf dbdev.tar.gz ./dbdev
+      - name: Tarball
+        run: cd ./cli/target/release && tar -czvf dbdev.tar.gz ./dbdev
 
       - name: Get Upload Url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -60,8 +60,6 @@ jobs:
           echo "build tar.gz"
           tar -czvf dbdev.tar.gz ./dbdev
           ls -al
-          cd ../../../
-          pwd
           echo "done"
 
       - uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -43,7 +43,7 @@ jobs:
         run: cargo build --release --verbose
         working-directory: ./cli
 
-      - name: Tarball
+      - name: Create Tarball
         run: cd ./cli/target/release && tar -czvf dbdev.tar.gz ./dbdev
 
       - name: Get Upload Url

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ matrix.box.os-and-arch != 'linux-amd64' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev
+          sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
 
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
           source "$HOME/.cargo/env"

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -122,7 +122,10 @@ jobs:
           cd ./target/release && Compress-Archive -Path ./dbdev.exe -Destination dbdev.zip
 
       - name: Get Upload Url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
+        run: |
+          $Json = Invoke-WebRequest -Uri https://api.github.com/repos/${{ github.repository }}/releases/latest | ConvertFrom-Json
+          $UploadUrl = $Json.upload_url
+          echo "UPLOAD_URL=$UploadUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -39,8 +39,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
-      - name: Build on linux-arm64
-        if: ${{ matrix.box.os-and-arch == 'linux-arm64' }}
+      - name: Build
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
@@ -49,16 +48,9 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          cd cli && cargo build --release
-
-      - uses: actions/checkout@v3
-      - name: Build on linux-amd64
-        if: ${{ matrix.box.os-and-arch == 'linux-amd64' }}
-        run: cargo build --release
-        working-directory: ./cli
-
-      - name: Create Tarball
-        run: cd ./cli/target/release && tar -czvf dbdev.tar.gz ./dbdev
+          cd cli
+          cargo build --release
+          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
       - name: Get Upload Url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -22,7 +22,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: |
             TODO: Write release notes
-          draft: true
+          draft: false
           prerelease: false
 
   build:
@@ -56,5 +56,5 @@ jobs:
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz
-          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}
-          asset_content_type: application/binary
+          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -52,19 +52,19 @@ jobs:
           toolchain: stable
 
       - uses: actions/checkout@v3
-      - name: Build
+      - name: Build and Package on Unix
+        if: ${{ matrix.box.os-and-arch != 'windows-amd64' }}
         run: |
           cd cli
           cargo build --release
-
-      - name: Package on Unix
-        if: ${{ matrix.box.os-and-arch != 'windows-amd64' }}
-        run: |
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
-      - name: Package on Windows
+      - uses: actions/checkout@v3
+      - name: Build and Package on Windows
         if: ${{ matrix.box.os-and-arch == 'windows-amd64' }}
         run: |
+          cd cli
+          cargo build --release
           cd ./target/release && Compress-Archive -Path ./dbdev -Destination dbdev.zip
 
       - name: Get Upload Url

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -60,6 +60,8 @@ jobs:
           echo "build tar.gz"
           tar -czvf dbdev.tar.gz ./dbdev
           ls -al
+          cd ../../../
+          pwd
           echo "done"
 
       - uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -55,11 +55,13 @@ jobs:
           cargo build --release
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
+      - name: Get Upload Url
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
+
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UPLOAD_URL: ${{ needs.create-release.outputs.upload_url }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -119,7 +119,7 @@ jobs:
         run: |
           cd cli
           cargo build --release
-          cd ./target/release && Compress-Archive -Path ./dbdev -Destination dbdev.zip
+          cd ./target/release && Compress-Archive -Path ./dbdev.exe -Destination dbdev.zip
 
       - name: Get Upload Url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -38,7 +38,8 @@ jobs:
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
-      - name: Install Rust
+      - uses: actions/checkout@v3
+      - name: Build on linux-arm64
         if: ${{ matrix.box.os-and-arch != 'linux-amd64' }}
         run: |
           sudo apt-get update
@@ -48,9 +49,10 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
+          cd cli && cargo build --release
 
       - uses: actions/checkout@v3
-      - name: Build
+      - name: Build on linux-amd64
         run: cargo build --release
         working-directory: ./cli
 

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body_path: |
+          body: |
             TODO: Write release notes
           draft: true
           prerelease: false

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -22,7 +22,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: |
             TODO: Write release notes
-          draft: true
+          draft: false
           prerelease: false
 
   build:
@@ -38,12 +38,12 @@ jobs:
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --release --verbose
+      - uses: actions/checkout@v3
+        run: cargo build --release
         working-directory: ./cli
 
-      - name: Tarball
+      - name: Create Tarball
         run: cd ./cli/target/release && tar -czvf dbdev.tar.gz ./dbdev
 
       - name: Get Upload Url
@@ -56,5 +56,5 @@ jobs:
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz
-          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}
-          asset_content_type: application/binary
+          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build on linux-arm64
-        if: ${{ matrix.box.os-and-arch != 'linux-amd64' }}
+        if: ${{ matrix.box.os-and-arch == 'linux-arm64' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
@@ -53,6 +53,7 @@ jobs:
 
       - uses: actions/checkout@v3
       - name: Build on linux-amd64
+        if: ${{ matrix.box.os-and-arch == 'linux-amd64' }}
         run: cargo build --release
         working-directory: ./cli
 

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,13 +49,9 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          echo "cd cli"
           cd cli
-          echo "cargo build --release"
           cargo build --release
-          echo "build tar.gz"
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
-          echo "done"
 
       - uses: actions/checkout@v3
       - name: Build on macOS

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -25,22 +25,57 @@ jobs:
           draft: false
           prerelease: false
 
-  build:
-    name: Release Artifacts
+  build-linux:
+    name: Release Artifacts on Linux
     needs:
       - create-release
     strategy:
       matrix:
         box:
-          - { runner: ubuntu-20.04, os-and-arch: linux-amd64, content-type: gzip, extension: tar.gz }
-          - { runner: arm-runner, os-and-arch: linux-arm64, content-type: gzip, extension: tar.gz }
-          - { runner: macos-12, os-and-arch: macos-amd64, content-type: gzip, extension: tar.gz }
-          - { runner: windows-2022, os-and-arch: windows-amd64, content-type: zip, extension: zip }
+          - { runner: ubuntu-20.04, os-and-arch: linux-amd64 }
+          - { runner: arm-runner, os-and-arch: linux-arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
       - name: Install dependencies
-        if: ${{ matrix.box.os-and-arch == 'linux-amd64' ||  matrix.box.os-and-arch == 'linux-arm64' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - uses: actions/checkout@v3
+      - name: Build and Package
+        run: |
+          cd cli
+          cargo build --release
+          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
+
+      - name: Get Upload Url
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./cli/target/release/dbdev.tar.gz
+          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}.tar.gz
+          asset_content_type: application/gzip
+
+  build-macos:
+    name: Release Artifacts on macOS
+    needs:
+      - create-release
+    runs-on: macos-12
+    timeout-minutes: 45
+    steps:
+      - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
@@ -53,15 +88,39 @@ jobs:
 
       - uses: actions/checkout@v3
       - name: Build and Package on Unix
-        if: ${{ matrix.box.os-and-arch != 'windows-amd64' }}
         run: |
           cd cli
           cargo build --release
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
+      - name: Get Upload Url
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./cli/target/release/dbdev.tar.gz
+          asset_name: dbdev-${{ github.ref_name }}-macos-amd64.tar.gz
+          asset_content_type: application/${{ matrix.box.content-type }}
+
+  build-windows:
+    name: Release Artifacts on Windows
+    needs:
+      - create-release
+    runs-on: windows-2022
+    timeout-minutes: 45
+    steps:
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
       - uses: actions/checkout@v3
       - name: Build and Package on Windows
-        if: ${{ matrix.box.os-and-arch == 'windows-amd64' }}
         run: |
           cd cli
           cargo build --release
@@ -76,6 +135,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./cli/target/release/dbdev.${{ matrix.box.extension }}
-          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}.${{ matrix.box.extension }}
-          asset_content_type: application/${{ matrix.box.content-type }}
+          asset_path: ./cli/target/release/dbdev.zip
+          asset_name: dbdev-${{ github.ref_name }}-windows-amd64.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,17 +49,12 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          pwd
+          echo "cd cli"
           cd cli
-          pwd
+          echo "cargo build --release"
           cargo build --release
-          echo "cd ./target/release"
-          cd ./target/release
-          pwd
-          ls -al
           echo "build tar.gz"
-          tar -czvf dbdev.tar.gz ./dbdev
-          ls -al
+          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
           echo "done"
 
       - uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  release:
+  create-release:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
@@ -20,23 +20,21 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body: |
-            Changes in this Release
-            - First Change
-            - Second Change
-          draft: false
+          body_path: |
+            TODO: Write release notes
+          draft: true
           prerelease: false
 
-  build-linux-gnu:
-    name: release artifacts
+  build:
+    name: Release Artifacts
     needs:
       - release
     strategy:
       matrix:
         box:
-          - { runner: ubuntu-20.04, arch: amd64 }
-          # - { runner: arm-runner, arch: arm64 }
-          # - { runner: macos-latest, arch: arm64 }
+          - { runner: ubuntu-20.04, os-and-arch: linux-amd64 }
+          # - { runner: arm-runner, os-and-arch: linux-arm64 }
+          # - { runner: macos-latest, os-and-arch: macos-arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
@@ -45,15 +43,18 @@ jobs:
         run: cargo build --release --verbose
         working-directory: ./cli
 
-      - name: Get upload url
+       name: Tarball
+       run: cd ./cli/target/release && tar -czvf dbdev.tar.gz ./dbdev
+
+      - name: Get Upload Url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
 
-      - name: Upload release asset
+      - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./cli/target/release/dbdev
-          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.arch }}
+          asset_path: ./cli/target/release/dbdev.tar.gz
+          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}
           asset_content_type: application/binary

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -44,12 +44,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl
 
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
-            rustup --version && \
-            rustc --version && \
-            cargo --version
-
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
           source "$HOME/.cargo/env"
+          rustup --version && rustc --version && cargo --version
+
 
       - uses: actions/checkout@v3
       - name: Build

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -34,7 +34,7 @@ jobs:
         box:
           - { runner: ubuntu-20.04, os-and-arch: linux-amd64 }
           - { runner: arm-runner, os-and-arch: linux-arm64 }
-          - { runner: macos-12, os-and-arch: macos-arm64 }
+          - { runner: macos-12, os-and-arch: macos-amd64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -34,16 +34,29 @@ jobs:
         box:
           - { runner: ubuntu-20.04, os-and-arch: linux-amd64 }
           - { runner: arm-runner, os-and-arch: linux-arm64 }
-          # - { runner: macos-latest, os-and-arch: macos-arm64 }
+          - { runner: macos-12, os-and-arch: macos-arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
-      - name: Build
+      - name: Build on linux
+        if: ${{ matrix.box.os-and-arch == 'linux-amd64' ||  matrix.box.os-and-arch == 'linux-arm64' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
 
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
+          source "$HOME/.cargo/env"
+          rustup --version && rustc --version && cargo --version
+
+          cd cli
+          cargo build --release
+          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
+
+      - uses: actions/checkout@v3
+      - name: Build on macOS
+        if: ${{ matrix.box.os-and-arch == 'macos-arm64' }}
+        run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -75,11 +75,6 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 45
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
-
       - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,10 +49,9 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          cd cli && \
-          cargo build --release && \
-          cd ./target/release && \
-          tar -czvf dbdev.tar.gz ./dbdev
+          cd cli
+          cargo build --release
+          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
       - uses: actions/checkout@v3
       - name: Build on macOS
@@ -62,10 +61,9 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          cd cli && \
-          cargo build --release && \
-          cd ./target/release && \
-          tar -czvf dbdev.tar.gz ./dbdev
+          cd cli
+          cargo build --release
+          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
       - name: Get Upload Url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -1,0 +1,59 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            Changes in this Release
+            - First Change
+            - Second Change
+          draft: false
+          prerelease: false
+
+  build-linux-gnu:
+    name: release artifacts
+    needs:
+      - release
+    strategy:
+      matrix:
+        box:
+          - { runner: ubuntu-20.04, arch: amd64 }
+          # - { runner: arm-runner, arch: arm64 }
+          # - { runner: macos-latest, arch: arm64 }
+    runs-on: ${{ matrix.box.runner }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --release --verbose
+        working-directory: ./cli
+
+      - name: Get upload url
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./cli/target/release/dbdev
+          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.arch }}
+          asset_content_type: application/binary

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,6 +49,8 @@ jobs:
             rustc --version && \
             cargo --version
 
+          source "$HOME/.cargo/env"
+
       - uses: actions/checkout@v3
       - name: Build
         run: cargo build --release

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -3,7 +3,7 @@ name: Release CLI
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   create-release:
@@ -33,7 +33,7 @@ jobs:
       matrix:
         box:
           - { runner: ubuntu-20.04, os-and-arch: linux-amd64 }
-          # - { runner: arm-runner, os-and-arch: linux-arm64 }
+          - { runner: arm-runner, os-and-arch: linux-arm64 }
           # - { runner: macos-latest, os-and-arch: macos-arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -55,13 +55,11 @@ jobs:
           cargo build --release
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
-      - name: Get Upload Url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
-
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPLOAD_URL: ${{ needs.create-release.outputs.upload_url }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -32,9 +32,10 @@ jobs:
     strategy:
       matrix:
         box:
-          - { runner: ubuntu-20.04, os-and-arch: linux-amd64 }
-          - { runner: arm-runner, os-and-arch: linux-arm64 }
-          - { runner: macos-12, os-and-arch: macos-amd64 }
+          - { runner: ubuntu-20.04, os-and-arch: linux-amd64, content-type: gzip, extension: tar.gz }
+          - { runner: arm-runner, os-and-arch: linux-arm64, content-type: gzip, extension: tar.gz }
+          - { runner: macos-12, os-and-arch: macos-amd64, content-type: gzip, extension: tar.gz }
+          - { runner: windows-2022, os-and-arch: windows-amd64, content-type: zip, extension: zip }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
@@ -44,16 +45,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
 
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
       - uses: actions/checkout@v3
       - name: Build
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
-          source "$HOME/.cargo/env"
-          rustup --version && rustc --version && cargo --version
-
           cd cli
           cargo build --release
+
+      - name: Package on Unix
+        if: ${{ matrix.box.os-and-arch != 'windows-amd64' }}
+        run: |
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
+
+      - name: Package on Windows
+        if: ${{ matrix.box.os-and-arch == 'windows-amd64' }}
+        run: |
+          cd ./target/release && Compress-Archive -Path ./dbdev -Destination dbdev.zip
 
       - name: Get Upload Url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
@@ -64,6 +76,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./cli/target/release/dbdev.tar.gz
-          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}.tar.gz
-          asset_content_type: application/gzip
+          asset_path: ./cli/target/release/dbdev.${{ matrix.box.extension }}
+          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}.${{ matrix.box.extension }}
+          asset_content_type: application/${{ matrix.box.content-type }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,9 +49,13 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
+          echo "cd cli"
           cd cli
+          echo "cargo build --release"
           cargo build --release
+          echo "build tar.gz"
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
+          echo "done"
 
       - uses: actions/checkout@v3
       - name: Build on macOS

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,9 +49,10 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          cd cli
-          cargo build --release
-          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
+          cd cli && \
+          cargo build --release && \
+          cd ./target/release && \
+          tar -czvf dbdev.tar.gz ./dbdev
 
       - uses: actions/checkout@v3
       - name: Build on macOS
@@ -61,9 +62,10 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          cd cli
-          cargo build --release
-          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
+          cd cli && \
+          cargo build --release && \
+          cd ./target/release && \
+          tar -czvf dbdev.tar.gz ./dbdev
 
       - name: Get Upload Url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -28,7 +28,7 @@ jobs:
   build:
     name: Release Artifacts
     needs:
-      - release
+      - create-release
     strategy:
       matrix:
         box:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,12 +49,17 @@ jobs:
           source "$HOME/.cargo/env"
           rustup --version && rustc --version && cargo --version
 
-          echo "cd cli"
+          pwd
           cd cli
-          echo "cargo build --release"
+          pwd
           cargo build --release
+          echo "cd ./target/release"
+          cd ./target/release
+          pwd
+          ls -al
           echo "build tar.gz"
-          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
+          tar -czvf dbdev.tar.gz ./dbdev
+          ls -al
           echo "done"
 
       - uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -38,24 +38,14 @@ jobs:
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
-      - name: Build on linux
+      - name: Install dependencies
         if: ${{ matrix.box.os-and-arch == 'linux-amd64' ||  matrix.box.os-and-arch == 'linux-arm64' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev pkg-config
 
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
-          source "$HOME/.cargo/env"
-          rustup --version && rustc --version && cargo --version
-
-          cd cli
-          cargo build --release
-          cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
-
       - uses: actions/checkout@v3
-      - name: Build on macOS
-        if: ${{ matrix.box.os-and-arch == 'macos-arm64' }}
+      - name: Build
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
           source "$HOME/.cargo/env"

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -22,7 +22,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: |
             TODO: Write release notes
-          draft: false
+          draft: true
           prerelease: false
 
   build:
@@ -38,12 +38,12 @@ jobs:
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
-      - name: Build
       - uses: actions/checkout@v3
-        run: cargo build --release
+      - name: Build
+        run: cargo build --release --verbose
         working-directory: ./cli
 
-      - name: Create Tarball
+      - name: Tarball
         run: cd ./cli/target/release && tar -czvf dbdev.tar.gz ./dbdev
 
       - name: Get Upload Url
@@ -56,5 +56,5 @@ jobs:
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz
-          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}.tar.gz
-          asset_content_type: application/gzip
+          asset_name: dbdev-${{ github.ref_name }}-${{ matrix.box.os-and-arch }}
+          asset_content_type: application/binary

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -38,9 +38,20 @@ jobs:
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 45
     steps:
+      - name: Install Rust
+        if: ${{ matrix.box.os-and-arch != 'linux-amd64' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends curl
+
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
+            rustup --version && \
+            rustc --version && \
+            cargo --version
+
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --release --verbose
+        run: cargo build --release
         working-directory: ./cli
 
       - name: Create Tarball

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -1,9 +1,14 @@
 name: Release CLI
 
+# on:
+#   push:
+#     tags:
+#       - 'v*'
 on:
   push:
-    tags:
-      - 'v*'
+    branches: ["feat/release-cli"]
+  pull_request:
+    branches: ["feat/release-cli"]
 
 jobs:
   release:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ matrix.box.os-and-arch != 'linux-amd64' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl
+          sudo apt-get install -y --no-install-recommends curl build-essential libssl-dev
 
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
           source "$HOME/.cargo/env"


### PR DESCRIPTION
This PR adds an action to release the CLI when a tag is pushed. This action will:

1. Create a release with placeholder release notes.
2. Build the CLIs for supported platforms. For now we build `linux-amd`, `linux-arm` and `macos-amd` versions.
3. Upload the binaries to the release.

We don't currently release native packages (apt/homebrew etc.) for linux or macos. Release notes need to be updated by hand for now.