### PR TITLE
use vendored openssl on linux to build a static binary

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1028,6 +1028,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.27.0+1.1.1v"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1044,7 @@ checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.69"
 clap = { version = "4.1.6", features = ["derive"] }
 dirs = "5.0.1"
 postgrest = "1.5.0"
-reqwest = { version = "0.11.14", features = ["json"] }
+reqwest = { version = "0.11.14", features = ["json", "native-tls-vendored"] }
 rpassword = "7.2.0"
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.94"


### PR DESCRIPTION
Use the `native-tls-vendored` feature of the `reqwest` crate to build a static binary on Linux. A static binary just works, while for a dynamically linked, people might need to install the correct openssl version.