### PR TITLE
Better method of getting `upload_url`

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -23,8 +23,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: v0.0.1
+          release_name: v0.0.1
           body: |
             TODO: Write release notes
           draft: false

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -1,14 +1,9 @@
 name: Release CLI
 
-# on:
-#   push:
-#     tags:
-#       - "v*"
-
-# used only for testing
 on:
   push:
-    branches: ['feat/better-upload-url']
+    tags:
+      - "v*"
 
 jobs:
   create-release:
@@ -23,8 +18,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v0.0.1
-          release_name: v0.0.1
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
           body: |
             TODO: Write release notes
           draft: false

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -5,7 +5,7 @@ name: Release CLI
 #     tags:
 #       - "v*"
 
-# used only for testing
+# used only for testing a
 on:
   push:
     branches: ['feat/better-upload-url']

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -1,9 +1,14 @@
 name: Release CLI
 
+# on:
+#   push:
+#     tags:
+#       - "v*"
+
+# used only for testing
 on:
   push:
-    tags:
-      - "v*"
+    branches: ['feat/better-upload-url']
 
 jobs:
   create-release:
@@ -24,6 +29,8 @@ jobs:
             TODO: Write release notes
           draft: false
           prerelease: false
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
 
   build-linux:
     name: Release Artifacts on Linux
@@ -55,12 +62,10 @@ jobs:
           cargo build --release
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
-      - name: Get Upload Url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
-
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
+          UPLOAD_URL: ${{ needs.create-release.outputs.upload_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
@@ -88,12 +93,10 @@ jobs:
           cargo build --release
           cd ./target/release && tar -czvf dbdev.tar.gz ./dbdev
 
-      - name: Get Upload Url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_ENV
-
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
+          UPLOAD_URL: ${{ needs.create-release.outputs.upload_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
@@ -121,15 +124,10 @@ jobs:
           cargo build --release
           cd ./target/release && Compress-Archive -Path ./dbdev.exe -Destination dbdev.zip
 
-      - name: Get Upload Url
-        run: |
-          $Json = Invoke-WebRequest -Uri https://api.github.com/repos/${{ github.repository }}/releases/latest | ConvertFrom-Json
-          $UploadUrl = $Json.upload_url
-          echo "UPLOAD_URL=$UploadUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
+          UPLOAD_URL: ${{ needs.create-release.outputs.upload_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -5,7 +5,7 @@ name: Release CLI
 #     tags:
 #       - "v*"
 
-# used only for testing a
+# used only for testing
 on:
   push:
     branches: ['feat/better-upload-url']


### PR DESCRIPTION
A fix to improve how the release workflow gets `upload_url`. Instead of calling the releases API, the `Create Release` step already knows about the `upload_url`, which we directly use.

The old method sometimes failed. E.g. see this run: https://github.com/supabase/dbdev/actions/runs/6235828891/job/16925848336. This new method should be more robust.