### PR TITLE
print 'Login successful' when login succeeds

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -126,6 +126,7 @@ async fn main() -> anyhow::Result<()> {
             // confirm that a registry with the given name exists
             config.get_registry(registry_name)?;
             commands::login::login(registry_name)?;
+            println!("Login successful");
             Ok(())
         }
     }


### PR DESCRIPTION
After `dbdev login` command succeeds, it will now print `Login successful` to give feedback to the user.