### PR TITLE
fix `database.dev` registry's api url

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -62,7 +62,7 @@ impl Default for Config {
         registries.insert(
             registry_name.to_string(),
             Registry {
-                base_url: url::Url::parse("https://database.dev")
+                base_url: url::Url::parse("https://xmuptpplfviifrbwmmtv.supabase.co")
                     .expect("Failed to parse database.dev url"),
                 api_key: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhtdXB0cHBsZnZpaWZyYndtbXR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODAxMDczNzIsImV4cCI6MTk5NTY4MzM3Mn0.z2CN0mvO2No8wSi46Gw59DFGCTJrzM0AQKsu_5k134s".to_string(),
             },

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -62,8 +62,8 @@ impl Default for Config {
         registries.insert(
             registry_name.to_string(),
             Registry {
-                base_url: url::Url::parse("https://xmuptpplfviifrbwmmtv.supabase.co")
-                    .expect("Failed to parse database.dev url"),
+                base_url: url::Url::parse("https://api.database.dev")
+                    .expect("Failed to parse api.database.dev url"),
                 api_key: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhtdXB0cHBsZnZpaWZyYndtbXR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODAxMDczNzIsImV4cCI6MTk5NTY4MzM3Mn0.z2CN0mvO2No8wSi46Gw59DFGCTJrzM0AQKsu_5k134s".to_string(),
             },
         );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a user logged in with `dbdev login`, the `base_url` saved in `~/.dbdev/config.toml` was `https://database.dev`. It should have been the API URL `https://xmuptpplfviifrbwmmtv.supabase.co`.

## What is the new behavior?

Correct API url is saved in the `config.toml` file.

## Additional context

N/A
