### PR TITLE
improve error msgs

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -40,6 +40,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +355,7 @@ dependencies = [
  "clap",
  "dirs 5.0.1",
  "postgrest",
+ "regex",
  "reqwest",
  "rpassword",
  "serde",
@@ -1224,6 +1234,35 @@ dependencies = [
  "redox_syscall 0.2.16",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.69"
 clap = { version = "4.1.6", features = ["derive"] }
 dirs = "5.0.1"
 postgrest = "1.5.0"
+regex = "1.9"
 reqwest = { version = "0.11.14", features = ["json", "native-tls-vendored"] }
 rpassword = "7.2.0"
 serde = { version = "1.0.156", features = ["derive"] }

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -45,6 +45,10 @@ pub async fn publish(
         }
     }
 
+    if num_published == 0 {
+        return Err(anyhow::anyhow!("No valid script file (.sql) found."));
+    }
+
     for upgrade_file in &payload.upgrade_files {
         let request =
             create_publich_package_upgrade_request(&payload.metadata.extension_name, upgrade_file);

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -24,6 +24,10 @@ pub async fn publish(
     let request = create_publish_package_request(&payload);
     client.publish_package(&jwt, &request).await?;
 
+    if payload.install_files.is_empty() {
+        return Err(anyhow::anyhow!("No valid script file (.sql) found."));
+    }
+
     let mut num_published = 0;
 
     for install_file in &payload.install_files {
@@ -43,10 +47,6 @@ pub async fn publish(
                 request.package_name, request.version
             );
         }
-    }
-
-    if num_published == 0 {
-        return Err(anyhow::anyhow!("No valid script file (.sql) found."));
     }
 
     for upgrade_file in &payload.upgrade_files {

--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -171,7 +171,7 @@ impl Payload {
                         continue;
                     }
                     if !util::is_valid_version(ver) {
-                        println!("Warning: file `{file_name}` will be skipped because its version (`{ver}`) is invalid");
+                        println!("Warning: file `{file_name}` will be skipped because its version (`{ver}`) is invalid. It should be have the format `major.minor.patch`.");
                         continue;
                     }
 
@@ -190,11 +190,11 @@ impl Payload {
                         continue;
                     }
                     if !util::is_valid_version(from_ver) {
-                        println!("Warning: file `{file_name}` will be skipped because its from version(`{from_ver}`) is invalid.");
+                        println!("Warning: file `{file_name}` will be skipped because its from version(`{from_ver}`) is invalid. It should be have the format `major.minor.patch`.");
                         continue;
                     }
                     if !util::is_valid_version(to_ver) {
-                        println!("Warning: file `{file_name}` will be skipped because its from version(`{to_ver}`) is invalid.");
+                        println!("Warning: file `{file_name}` will be skipped because its from version(`{to_ver}`) is invalid. It should be have the format `major.minor.patch`.");
                         continue;
                     }
 

--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -1,7 +1,6 @@
 use crate::util;
 
 use anyhow::Context;
-use regex::Regex;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -147,7 +146,7 @@ impl Payload {
 
         if !util::is_valid_extension_name(&extension_name) {
             return Err(anyhow::anyhow!(
-                "invalid extension name detected {}",
+                "Invalid extension name detected: {}. It must begin with an alphabet, contain only alphanumeric characters or `_` and should be between 2 and 32 characters long.",
                 extension_name
             ));
         }
@@ -226,16 +225,10 @@ impl ControlFileRef {
 
     // Name of the extension. Used in the `create extesnion <extension_name>`
     fn extension_name(&self) -> anyhow::Result<String> {
-        let name_regex = Regex::new(r"^[A-z][A-z0-9\_]{2,32}$").expect("regex is valid");
-        let name = self
-            .filename
+        self.filename
             .strip_suffix(".control")
             .context("failed to read extension name from control file")
-            .map(str::to_string)?;
-        if !name_regex.is_match(&name) {
-            return Err(anyhow::anyhow!("extension name must begin with an alphabet, contain only alphanumeric characters or `_` and should be between 2 and 32 characters long."));
-        }
-        Ok(name)
+            .map(str::to_string)
     }
 
     // A comment (any string) about the extension. The comment is applied when initially creating

--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -1,6 +1,7 @@
 use crate::util;
 
 use anyhow::Context;
+use regex::Regex;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -225,10 +226,16 @@ impl ControlFileRef {
 
     // Name of the extension. Used in the `create extesnion <extension_name>`
     fn extension_name(&self) -> anyhow::Result<String> {
-        self.filename
+        let name_regex = Regex::new(r"^[A-z][A-z0-9\_]{2,32}$").expect("regex is valid");
+        let name = self
+            .filename
             .strip_suffix(".control")
             .context("failed to read extension name from control file")
-            .map(str::to_string)
+            .map(str::to_string)?;
+        if !name_regex.is_match(&name) {
+            return Err(anyhow::anyhow!("extension name must begin with an alphabet, contain only alphanumeric characters or `_` and should be between 2 and 32 characters long."));
+        }
+        Ok(name)
     }
 
     // A comment (any string) about the extension. The comment is applied when initially creating
@@ -264,7 +271,9 @@ impl ControlFileRef {
                 return self.read_control_line_value(line);
             }
         }
-        Err(anyhow::anyhow!("default version is required"))
+        Err(anyhow::anyhow!(
+            "`default_version` in control file is required"
+        ))
     }
 
     fn read_control_line_value(&self, line: &str) -> anyhow::Result<String> {

--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -166,31 +166,46 @@ impl Payload {
             match &parts[..] {
                 [file_ext_name, ver] => {
                     // Make sure the file's extension name matches the control file
-                    if file_ext_name == &extension_name && util::is_valid_version(ver) {
-                        let ifile = InstallFile {
-                            filename: file_name.to_string(),
-                            version: ver.to_string(),
-                            body: fs::read_to_string(&path)
-                                .context(format!("Failed to read file {}", &file_name))?,
-                        };
-                        install_files.push(ifile);
+                    if file_ext_name != &extension_name {
+                        println!("Warning: file `{file_name}` will be skipped because its extension name(`{file_ext_name}`) doesn't match `{extension_name}`");
+                        continue;
                     }
+                    if !util::is_valid_version(ver) {
+                        println!("Warning: file `{file_name}` will be skipped because its version (`{ver}`) is invalid");
+                        continue;
+                    }
+
+                    let ifile = InstallFile {
+                        filename: file_name.to_string(),
+                        version: ver.to_string(),
+                        body: fs::read_to_string(&path)
+                            .context(format!("Failed to read file {}", &file_name))?,
+                    };
+                    install_files.push(ifile);
                 }
                 [file_ext_name, from_ver, to_ver] => {
                     // Make sure the file's extension name matches the control file
-                    if file_ext_name == &extension_name
-                        && util::is_valid_version(from_ver)
-                        && util::is_valid_version(to_ver)
-                    {
-                        let ufile = UpgradeFile {
-                            filename: file_name.to_string(),
-                            from_version: from_ver.to_string(),
-                            to_version: to_ver.to_string(),
-                            body: fs::read_to_string(&path)
-                                .context(format!("Failed to read file {}", &file_name))?,
-                        };
-                        upgrade_files.push(ufile);
+                    if file_ext_name != &extension_name {
+                        println!("Warning: file `{file_name}` will be skipped because its extension name(`{file_ext_name}`) doesn't match `{extension_name}`");
+                        continue;
                     }
+                    if !util::is_valid_version(from_ver) {
+                        println!("Warning: file `{file_name}` will be skipped because its from version(`{from_ver}`) is invalid.");
+                        continue;
+                    }
+                    if !util::is_valid_version(to_ver) {
+                        println!("Warning: file `{file_name}` will be skipped because its from version(`{to_ver}`) is invalid.");
+                        continue;
+                    }
+
+                    let ufile = UpgradeFile {
+                        filename: file_name.to_string(),
+                        from_version: from_ver.to_string(),
+                        to_version: to_ver.to_string(),
+                        body: fs::read_to_string(&path)
+                            .context(format!("Failed to read file {}", &file_name))?,
+                    };
+                    upgrade_files.push(ufile);
                 }
                 _ => (),
             }

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use regex::Regex;
 use sqlx::postgres::PgConnection;
 use sqlx::Connection;
 use std::fs::{File, OpenOptions};
@@ -10,8 +11,9 @@ pub async fn get_connection(connection_str: &str) -> anyhow::Result<PgConnection
         .context("Failed to establish PostgreSQL connection")
 }
 
-pub fn is_valid_extension_name(_name: &str) -> bool {
-    true
+pub fn is_valid_extension_name(name: &str) -> bool {
+    let name_regex = Regex::new(r"^[A-z][A-z0-9\_]{2,32}$").expect("regex is valid");
+    name_regex.is_match(name)
 }
 
 pub fn is_valid_version(_version: &str) -> bool {

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -16,7 +16,23 @@ pub fn is_valid_extension_name(name: &str) -> bool {
     name_regex.is_match(name)
 }
 
-pub fn is_valid_version(_version: &str) -> bool {
+pub fn is_valid_version(version: &str) -> bool {
+    let nums: Vec<&str> = version.split('.').collect();
+    if nums.len() != 3 {
+        println!("1");
+        return false;
+    }
+
+    for num_str in nums {
+        let num: i16 = match num_str.parse() {
+            Ok(n) => n,
+            _ => return false,
+        };
+        if num < 0 {
+            return false;
+        }
+    }
+
     true
 }
 


### PR DESCRIPTION
Improve error messages shown to the user when using the CLI and the following happens:

1. No `.sql` file is found in the extension folder.
2. A script file's extension name or version are invalid.