### PR TITLE
check cli version before release

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -3,7 +3,7 @@ name: Release CLI
 on:
   push:
     tags:
-      - "test*"
+      - "v*"
 
 jobs:
   create-release:
@@ -21,12 +21,8 @@ jobs:
       - name: Check Release Version is Same as CLI Version
         if: ${{ !endsWith(github.ref, steps.read_cli_version.outputs.value) }}
         run: |
-          echo "Tag version ${{ github.ref }} is not equal to Cargo.toml version ${{ steps.read_cli_version.outputs.value }}";
+          echo "Tag version ${{ github.ref }} doesn't match Cargo.toml version ${{ steps.read_cli_version.outputs.value }}";
           echo "Did you forget to update version in Cargo.toml?"
-          exit 1
-      - name: Always fail during testing to avoid creating a release
-        run: |
-          echo "Failing to avoid creating a release"
           exit 1
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -21,7 +21,9 @@ jobs:
       - name: Check Release Version is Same as CLI Version
         if: ${{ github.ref }} != test${{ steps.read_cli_version.outputs.value }}
         run: |
-          echo "Tag version ${{ github.ref }} is not equal to Cargo.toml version {{ steps.read_cli_version.outputs.value }}"; exit 1
+          echo "Tag version ${{ github.ref }} is not equal to Cargo.toml version ${{ steps.read_cli_version.outputs.value }}";
+          echo "Did you forget to update version in Cargo.toml?"
+          exit 1
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -19,10 +19,14 @@ jobs:
           file: './cli/Cargo.toml'
           field: 'package.version'
       - name: Check Release Version is Same as CLI Version
-        if: ${{ github.ref }} != test${{ steps.read_cli_version.outputs.value }}
+        if: endsWith(${{ github.ref }}, ${{ steps.read_cli_version.outputs.value }})
         run: |
           echo "Tag version ${{ github.ref }} is not equal to Cargo.toml version ${{ steps.read_cli_version.outputs.value }}";
           echo "Did you forget to update version in Cargo.toml?"
+          exit 1
+      - name: Always fail during testing to avoid creating a release
+        run: |
+          echo "Failing to avoid creating a release"
           exit 1
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -19,7 +19,7 @@ jobs:
           file: './cli/Cargo.toml'
           field: 'package.version'
       - name: Check Release Version is Same as CLI Version
-        if: endsWith(${{ github.ref }}, ${{ steps.read_cli_version.outputs.value }})
+        if: ${{ !endsWith(github.ref, steps.read_cli_version.outputs.value) }}
         run: |
           echo "Tag version ${{ github.ref }} is not equal to Cargo.toml version ${{ steps.read_cli_version.outputs.value }}";
           echo "Did you forget to update version in Cargo.toml?"

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -12,6 +12,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Read CLI version
+        uses: SebRollen/toml-action@v1.0.2
+        id: read_cli_version
+        with:
+          file: './cli/Cargo.toml'
+          field: 'package.version'
+      - name: Check Release Version is Same as CLI Version
+        if: ${{ github.ref }} != v${{ steps.read_cli_version.outputs.value }}
+        run: |
+          echo "Tag version ${{ github.ref }} is not equal to Cargo.toml version {{ steps.read_cli_version.outputs.value }}"; exit 1
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -3,7 +3,7 @@ name: Release CLI
 on:
   push:
     tags:
-      - "v*"
+      - "test*"
 
 jobs:
   create-release:
@@ -19,7 +19,7 @@ jobs:
           file: './cli/Cargo.toml'
           field: 'package.version'
       - name: Check Release Version is Same as CLI Version
-        if: ${{ github.ref }} != v${{ steps.read_cli_version.outputs.value }}
+        if: ${{ github.ref }} != test${{ steps.read_cli_version.outputs.value }}
         run: |
           echo "Tag version ${{ github.ref }} is not equal to Cargo.toml version {{ steps.read_cli_version.outputs.value }}"; exit 1
       - name: Create Release


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

It was possible to release a CLI with version different than the tag which created the release. E.g. recently a tag `v0.1.1` released a CLI with version `0.1.0`. 

## What is the new behavior?

The release action will now check whether the version in the tag and the `Cargo.toml` file match or not. If they don't match, the release action fails.

## Additional context

N/A