### PR TITLE
add links to the TLE publishing docs in README.md and database.dev home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # dbdev
 
-dbdev is a package manager for PostgreSQL [trusted language extensions](https://github.com/aws/pg_tle). At this time the registry is limited to a handful of pre-loaded pglets (short for Postgres applets, pronounced "piglet"). In the coming weeks we'll enable third party contributions.
+dbdev is a package manager for PostgreSQL [trusted language extensions (TLE)](https://github.com/aws/pg_tle). To publish your own TLE, follow [the publishing guide](https://supabase.github.io/dbdev/).
 
 For more info, check out the [dbdev release blog post](https://supabase.com/blog/dbdev) or start searching for packages on [database.dev](https://database.dev).
 

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -70,7 +70,9 @@ const IndexPage: NextPageWithLayout = () => {
             Popular packages
           </p>
           <div className="grid sm:grid-cols-8 md:grid-cols-12 gap-4">
-            {data?.map((pkg: any) => <PackageCard key={pkg.id} pkg={pkg} />)}
+            {data?.map((pkg: any) => (
+              <PackageCard key={pkg.id} pkg={pkg} />
+            ))}
           </div>
         </div>
 
@@ -93,6 +95,14 @@ const IndexPage: NextPageWithLayout = () => {
               <Link href="/installer" className="border-b">
                 here
               </Link>
+              . Publish your own trusted language extension by following{' '}
+              <Link
+                href="https://supabase.github.io/dbdev/"
+                className="border-b"
+              >
+                the publishing guide
+              </Link>
+              .
             </p>
           </div>
         </div>

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -70,9 +70,7 @@ const IndexPage: NextPageWithLayout = () => {
             Popular packages
           </p>
           <div className="grid sm:grid-cols-8 md:grid-cols-12 gap-4">
-            {data?.map((pkg: any) => (
-              <PackageCard key={pkg.id} pkg={pkg} />
-            ))}
+            {data?.map((pkg: any) => <PackageCard key={pkg.id} pkg={pkg} />)}
           </div>
         </div>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The TLE publishing docs are not linked to.

## What is the new behavior?

Links to the TLE publishing docs are added to the README.md and in the database.dev home page.

## Additional context

Fixes #114 
