### PR TITLE
bump version to 0.1.2

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "dbdev"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbdev"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 authors = ["supabase"]
 


### PR DESCRIPTION
To prepare for the `0.1.2` release. No new features in this release. It is being cut to fix the version in the shipped CLI binary. In the `0.1.1` release the binary's version was accidentally left at `0.1.0`.