### PR TITLE
update installation section for Linux packages and Scoop

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -20,11 +20,22 @@ Installation is available through a native package, binary download or building 
     brew install supabase/tap/dbdev
     ```
 
-    Not yet available as a Linux package. Read the next sections to download a binary or build from source.
+    #### Linux packages
+
+    Debian Linux packages are provided in [Releases](https://github.com/supabase/dbdev/releases).
+    To install, download the `.deb` file and run the following:
+
+    ```
+    sudo dpkg -i <...>.deb
+    ```
 
 === "Windows"
 
-    Not yet available as a [Scoop](https://scoop.sh/) package. Read the next sections to download a binary or build from source.
+    Install the CLI with [Scoop](https://scoop.sh/).
+    ```
+    scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
+    scoop install dbdev
+    ```
 
 ### Binary Download
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Installation instructions for `dbdev` CLI missing using .deb package and Scoop.

## What is the new behavior?

Added installation instructions for `dbdev` CLI using Linux .deb package and Scoop.

## Additional context

N/A