### PR TITLE
allow installing multiple versions of an extension

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs 5.0.1",
+ "futures",
  "postgrest",
  "regex",
  "reqwest",
@@ -511,6 +512,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +543,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-intrusive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +563,12 @@ dependencies = [
  "lock_api",
  "parking_lot 0.11.2",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
@@ -566,10 +599,13 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["supabase"]
 anyhow = "1.0.69"
 clap = { version = "4.1.6", features = ["derive"] }
 dirs = "5.0.1"
+futures = "0.3"
 postgrest = "1.5.0"
 regex = "1.9"
 reqwest = { version = "0.11.14", features = ["json", "native-tls-vendored"] }

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -1,35 +1,74 @@
+use std::collections::HashSet;
+
 use crate::models::Payload;
 use anyhow::Context;
+use futures::TryStreamExt;
 use sqlx::postgres::PgConnection;
 
 pub async fn install(payload: &Payload, mut conn: PgConnection) -> anyhow::Result<()> {
+    let existing_versions = extension_versions(&mut conn, &payload.metadata.extension_name).await?;
+    let mut versions_installed_now = HashSet::new();
+
+    let mut installed_extension_once = !existing_versions.is_empty();
+
     for install_file in &payload.install_files {
-        sqlx::query("select pgtle.install_extension($1, $2, $3, $4, $5)")
-            .bind(&payload.metadata.extension_name)
-            .bind(&install_file.version)
-            .bind(&payload.metadata.comment)
-            .bind(&install_file.body)
-            .bind(&payload.metadata.requires)
-            .execute(&mut conn)
-            .await
-            .context(format!(
-                "failed to install extension version {}",
-                install_file.filename
-            ))?;
+        if !existing_versions.contains(&install_file.version) {
+            if installed_extension_once {
+                sqlx::query("select pgtle.install_extension_version_sql($1, $2, $3)")
+                    .bind(&payload.metadata.extension_name)
+                    .bind(&install_file.version)
+                    .bind(&install_file.body)
+                    .execute(&mut conn)
+                    .await
+                    .context(format!(
+                        "failed to install extension version {}",
+                        install_file.filename
+                    ))?;
+                println!("Installed version {}", install_file.version);
+                versions_installed_now.insert(install_file.version.clone());
+            } else {
+                sqlx::query("select pgtle.install_extension($1, $2, $3, $4, $5)")
+                    .bind(&payload.metadata.extension_name)
+                    .bind(&install_file.version)
+                    .bind(&payload.metadata.comment)
+                    .bind(&install_file.body)
+                    .bind(&payload.metadata.requires)
+                    .execute(&mut conn)
+                    .await
+                    .context(format!(
+                        "failed to install extension {}",
+                        install_file.filename
+                    ))?;
+                println!("Installed version {}", install_file.version);
+                versions_installed_now.insert(install_file.version.clone());
+                installed_extension_once = true;
+            }
+        }
     }
 
+    let existing_update_paths = update_paths(&mut conn, &payload.metadata.extension_name).await?;
+
     for upgrade_file in &payload.upgrade_files {
-        sqlx::query("select pgtle.install_update_path($1, $2, $3, $4)")
-            .bind(&payload.metadata.extension_name)
-            .bind(&upgrade_file.from_version)
-            .bind(&upgrade_file.to_version)
-            .bind(&upgrade_file.body)
-            .execute(&mut conn)
-            .await
-            .context(format!(
-                "failed to install extension version {}",
-                upgrade_file.filename
-            ))?;
+        if !existing_update_paths.contains(&UpdatePath {
+            source: upgrade_file.from_version.clone(),
+            target: upgrade_file.to_version.clone(),
+        }) {
+            sqlx::query("select pgtle.install_update_path($1, $2, $3, $4)")
+                .bind(&payload.metadata.extension_name)
+                .bind(&upgrade_file.from_version)
+                .bind(&upgrade_file.to_version)
+                .bind(&upgrade_file.body)
+                .execute(&mut conn)
+                .await
+                .context(format!(
+                    "failed to install update path {}",
+                    upgrade_file.filename
+                ))?;
+            println!(
+                "Installed update file from version {} to {}",
+                upgrade_file.from_version, upgrade_file.to_version
+            );
+        }
     }
 
     sqlx::query("select pgtle.set_default_version($1, $2)")
@@ -42,5 +81,59 @@ pub async fn install(payload: &Payload, mut conn: PgConnection) -> anyhow::Resul
             &payload.metadata.default_version
         ))?;
 
+    if !versions_installed_now.contains(&payload.metadata.default_version) {
+        println!(
+            "Set default version to {}",
+            payload.metadata.default_version
+        );
+    }
+
     Ok(())
+}
+
+#[derive(sqlx::FromRow)]
+struct ExtensionVersion {
+    version: String,
+}
+
+async fn extension_versions(
+    conn: &mut PgConnection,
+    extension_name: &str,
+) -> anyhow::Result<HashSet<String>> {
+    let mut rows = sqlx::query_as::<_, ExtensionVersion>(
+        "select version from pgtle.available_extension_versions() where name = $1",
+    )
+    .bind(extension_name)
+    .fetch(conn);
+
+    let mut versions = HashSet::new();
+    while let Some(installed_version) = rows.try_next().await? {
+        versions.insert(installed_version.version);
+    }
+
+    Ok(versions)
+}
+
+#[derive(sqlx::FromRow, PartialEq, Eq, Hash)]
+struct UpdatePath {
+    source: String,
+    target: String,
+}
+
+async fn update_paths(
+    conn: &mut PgConnection,
+    extension_name: &str,
+) -> anyhow::Result<HashSet<UpdatePath>> {
+    let mut rows = sqlx::query_as::<_, UpdatePath>(
+        "select source, target from pgtle.extension_update_paths($1);",
+    )
+    .bind(extension_name)
+    .fetch(conn);
+
+    let mut paths = HashSet::new();
+    while let Some(update_path) = rows.try_next().await? {
+        paths.insert(update_path);
+    }
+
+    Ok(paths)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Running `dbdev install` command failed if another version of a TLE was already installed in the database.

## What is the new behavior?

The CLI now checks the installed versions of the TLE before calling the `pgtle.install_extension_version_sql`/`pgtle.install_extension` functions. If a version is already installed, that install file is skipped. Similarly update files are also skipped if an update path is already registered. The `pgtle.install_extension_version_sql` function of only ever called once, later versions are installed using the `pgtle.install_extension` function.

We also print more information, like versions of installed files and new default version, for better user feedback.

## Additional context

Fixes #121 