### PR TITLE
path argument defaults to current dir if omitted

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -49,7 +49,7 @@ Your extension is ready to publish. Its name is `hello_world` and version is `0.
 Now run the `dbdev publish` command to publish it.
 
 ```
-dbdev publish --path /path/to/my_first_tle
+dbdev publish
 ```
 
 Your extension is now published to `database.dev` and visible under your account profile. You can visit your account profile from the account drop-down at the top right. Users can now install your extension using the [dbdev in-database client](https://database.dev/installer).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

1. `dbdev publish` and `dbdev install` commands required an `--path` option to be passed.
2. It was possible to pass both `--path` and `--package` options.

## What is the new behavior?

1. Both these commands will now use the current directory if `--path` is omitted.
2. Only one of `--path` or `--package` can be passed.

## Additional context

This is done to make it possible to run `dbdev publish`/`dbdev install` from the extension directory without adding `--path .` which is just redundant.
