### PR TITLE
move database.dev/installer page content into docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,6 @@ dbdev is a package manager for Postgres [trusted language extensions](https://gi
 - dbdev CLI: a CLI for publishing TLEs to a registry.
 - dbdev client: an in-database client for installing TLEs from registries.
 
-If you want to publish your own TLE, you will need the dbdev CLI. Follow its [installation instructions](install.md) to get started.
+If you want to publish your own TLE, you will need the dbdev CLI. Follow its [installation instructions](install-cli.md) to get started.
 
 If you want to install an extension from the registry, you will need the SQL dbdev client. Follow its [installation instructions](https://database.dev/installer) to enable it in your database.

--- a/docs/install-cli.md
+++ b/docs/install-cli.md
@@ -52,4 +52,4 @@ Alternatively, you can build the binary from source. You will need to have [Rust
 
 If you have [cargo-install](https://doc.rust-lang.org/cargo/commands/cargo-install.html), you can perform all the above steps with a single command: `cargo install --git https://github.com/supabase/dbdev.git dbdev`.
 
-Now you're ready to [publish your first package](publish.md).
+Now you're ready to [publish your first package](publish-extension.md).

--- a/docs/install-in-db-client.md
+++ b/docs/install-in-db-client.md
@@ -1,0 +1,71 @@
+You can install extensions available on the database.dev registry using the dbdev in-database client. The dbdev client is itself an extension which you can install by following the instructions below.
+
+## Installation
+
+Before you can install the dbdev extension into your database, ensure you have the following dependencies already installed:
+
+- [pg_tle](https://github.com/aws/pg_tle)
+- [pgsql-http](https://github.com/pramsey/pgsql-http)
+
+!!! note
+
+    If you database is running on Supabase, the above dependencies are already installed.
+
+Run the following SQL to install the client:
+
+```sql
+create extension if not exists http with schema extensions;
+create extension if not exists pg_tle;
+select pgtle.uninstall_extension_if_exists('supabase-dbdev');
+drop extension if exists "supabase-dbdev";
+select
+    pgtle.install_extension(
+        'supabase-dbdev',
+        resp.contents ->> 'version',
+        'PostgreSQL package manager',
+        resp.contents ->> 'sql'
+    )
+from http(
+    (
+        'GET',
+        'https://api.database.dev/rest/v1/'
+        || 'package_versions?select=sql,version'
+        || '&package_name=eq.supabase-dbdev'
+        || '&order=version.desc'
+        || '&limit=1',
+        array[
+            ('apiKey', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhtdXB0cHBsZnZpaWZyYndtbXR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODAxMDczNzIsImV4cCI6MTk5NTY4MzM3Mn0.z2CN0mvO2No8wSi46Gw59DFGCTJrzM0AQKsu_5k134s')::http_header
+        ],
+        null,
+        null
+    )
+) x,
+lateral (
+    select
+        ((row_to_json(x) -> 'content') #>> '{}')::json -> 0
+) resp(contents);
+create extension "supabase-dbdev";
+select dbdev.install('supabase-dbdev');
+drop extension if exists "supabase-dbdev";
+create extension "supabase-dbdev";
+```
+
+## Use
+
+Once the client is installed, you an install a TLE available on database.dev by running SQL that looks like the following:
+
+```sql
+select dbdev.install(<extension_name>);
+create extension <extension_name>
+    schema <schema>
+    version <version>;
+```
+
+For example, to install pg_headerkit version 1.0.0 in schema public run:
+
+```sql
+select dbdev.install('burggraf-pg_headerkit');
+create extension "burggraf-pg_headerkit"
+    schema 'public'
+    version '1.0.0';
+```

--- a/docs/publish-extension.md
+++ b/docs/publish-extension.md
@@ -23,7 +23,7 @@ mkdir my_first_tle
 cd my_first_tle
 ```
 
-Next create a `hello_world--0.0.1.sql` file, which will contain your extension's SQL objects.  Add the following function definition to this file:
+Next create a `hello_world--0.0.1.sql` file, which will contain your extension's SQL objects. Add the following function definition to this file:
 
 ```sql
 create function greet(name text default 'world')
@@ -52,4 +52,4 @@ Now run the `dbdev publish` command to publish it.
 dbdev publish
 ```
 
-Your extension is now published to `database.dev` and visible under your account profile. You can visit your account profile from the account drop-down at the top right. Users can now install your extension using the [dbdev in-database client](https://database.dev/installer).
+Your extension is now published to `database.dev` and visible under your account profile. You can visit your account profile from the account drop-down at the top right. Users can now install your extension using the [dbdev in-database client](install-in-db-client.md).

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -7,8 +7,9 @@ repo_url: https://github.com/supabase/dbdev
 
 nav:
     - Welcome: 'index.md'
-    - Install CLI: 'install.md'
-    - Publish a Package: 'publish.md'
+    - Install CLI: 'install-cli.md'
+    - Publish a Package: 'publish-extension.md'
+    - Install a Package: 'install-in-db-client.md'
     - Structure of a Postgres Extension: 'extension_structure.md'
 
 theme:
@@ -18,6 +19,7 @@ theme:
     homepage: https://supabase.github.io/dbdev
     features:
       - navigation.expand
+      - content.code.copy
     palette:
         primary: black
         accent: light green

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -90,7 +90,10 @@ const IndexPage: NextPageWithLayout = () => {
             <p className="dark:text-white">
               Install the dbdev client in your PostgreSQL database by following
               the guide{' '}
-              <Link href="https://supabase.github.io/dbdev/install-in-db-client/" className="border-b">
+              <Link
+                href="https://supabase.github.io/dbdev/install-in-db-client/"
+                className="border-b"
+              >
                 here
               </Link>
               . Publish your own trusted language extension by following{' '}

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -90,7 +90,7 @@ const IndexPage: NextPageWithLayout = () => {
             <p className="dark:text-white">
               Install the dbdev client in your PostgreSQL database by following
               the guide{' '}
-              <Link href="/installer" className="border-b">
+              <Link href="https://supabase.github.io/dbdev/install-in-db-client/" className="border-b">
                 here
               </Link>
               . Publish your own trusted language extension by following{' '}

--- a/website/pages/installer.tsx
+++ b/website/pages/installer.tsx
@@ -1,87 +1,20 @@
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import Layout from '~/components/layouts/Layout'
 import Markdown from '~/components/ui/Markdown'
 import { NextPageWithLayout } from '~/lib/types'
 
 const InstallerPage: NextPageWithLayout = () => {
-  return (
-    <>
-      <Head>
-        <title>Installer | The Database Package Manager</title>
-      </Head>
+  return null
+}
 
-      <div className="mb-16">
-        <Markdown>
-          {`# Install dbdev
-
-To install the dbdev extension into your database, ensure you have the following dependencies installed and then run the following SQL:
-
-Requires:
-  - pg_tle: https://github.com/aws/pg_tle
-  - pgsql-http: https://github.com/pramsey/pgsql-http
-
-*If your database is running on [Supabase](https://supabase.com), these dependencies are already installed.*
-
-\`\`\`sql
-create extension if not exists http with schema extensions;
-create extension if not exists pg_tle;
-select pgtle.uninstall_extension_if_exists('supabase-dbdev');
-drop extension if exists "supabase-dbdev";
-select
-    pgtle.install_extension(
-        'supabase-dbdev',
-        resp.contents ->> 'version',
-        'PostgreSQL package manager',
-        resp.contents ->> 'sql'
-    )
-from http(
-    (
-        'GET',
-        'https://api.database.dev/rest/v1/'
-        || 'package_versions?select=sql,version'
-        || '&package_name=eq.supabase-dbdev'
-        || '&order=version.desc'
-        || '&limit=1',
-        array[
-            ('apiKey', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhtdXB0cHBsZnZpaWZyYndtbXR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODAxMDczNzIsImV4cCI6MTk5NTY4MzM3Mn0.z2CN0mvO2No8wSi46Gw59DFGCTJrzM0AQKsu_5k134s')::http_header
-        ],
-        null,
-        null
-    )
-) x,
-lateral (
-    select
-        ((row_to_json(x) -> 'content') #>> '{}')::json -> 0
-) resp(contents);
-create extension "supabase-dbdev";
-select dbdev.install('supabase-dbdev');
-drop extension if exists "supabase-dbdev";
-create extension "supabase-dbdev";
-\`\`\`
-
-## Use
-
-Once the client is installed, you an install a TLE available on [database.dev](https://database.dev/) by running SQL that looks like the following:
-
-\`\`\`sql
-select dbdev.install(<extension_name>);
-create extension <extension_name>
-    schema <schema>
-    version <version>;
-\`\`\`
-
-For example, to install [pg_headerkit](https://database.dev/burggraf/pg_headerkit) version \`1.0.0\` in schema \`public\` run:
-
-\`\`\`sql
-select dbdev.install('burggraf-pg_headerkit');
-create extension "burggraf-pg_headerkit"
-    schema 'public'
-    version '1.0.0';
-\`\`\``}
-        </Markdown>
-      </div>
-    </>
-  )
+export async function getServerSideProps() {
+  return {
+    redirect: {
+      destination: '/supabase/dbdev',
+      permanent: true,
+    },
+  }
 }
 
 InstallerPage.getLayout = (page) => <Layout>{page}</Layout>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Docs about how to install dbdev in the database is on database.dev while rest of the docs are published separately.

## What is the new behavior?

Content of the the installer page is moved into the docs. The /installer url is now redirected to /supabase/dbdev page which contains similar information.

## Additional context

Enabled a setting in mkdocs.yaml file to show a copy button in code snippets in docs.
