### PR TITLE
fix: update paths were not installed in dbdev install command

### DIFF
--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -125,7 +125,7 @@ async fn update_paths(
     extension_name: &str,
 ) -> anyhow::Result<HashSet<UpdatePath>> {
     let mut rows = sqlx::query_as::<_, UpdatePath>(
-        "select source, target from pgtle.extension_update_paths($1);",
+        "select source, target from pgtle.extension_update_paths($1) where path is not null;",
     )
     .bind(extension_name)
     .fetch(conn);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

pgtle update paths were not installed when running `dbdev install` command

## What is the new behavior?

Update paths will be correctly installed.

## Additional context

The `pgtle.extension_update_paths` function returns values for `source` and `target` columns even when no update paths are installed, although their `path` column is null. Adding the `where path is not null` clause filters out those unwanted paths. 
