### PR TITLE
chore: bump dbdev CLI version to 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # dbdev
 
-dbdev is a package manager for Postgres [trusted language extensions (TLE)](https://github.com/aws/pg_tle). 
+dbdev is a package manager for Postgres [trusted language extensions (TLE)](https://github.com/aws/pg_tle).
 
 - Search for packages on [database.dev](https://database.dev).
 - Documentation: [supabase.github.io/dbdev/](https://supabase.github.io/dbdev/)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "dbdev"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbdev"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["supabase"]
 


### PR DESCRIPTION
Bumps dbdev CLI version to 0.1.4 to prepare for its release.