### PR TITLE
`dbdev ls` command

### DIFF
--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -115,12 +115,12 @@ async fn extension_versions(
 }
 
 #[derive(sqlx::FromRow, PartialEq, Eq, Hash)]
-struct UpdatePath {
-    source: String,
-    target: String,
+pub(crate) struct UpdatePath {
+    pub(crate) source: String,
+    pub(crate) target: String,
 }
 
-async fn update_paths(
+pub(crate) async fn update_paths(
     conn: &mut PgConnection,
     extension_name: &str,
 ) -> anyhow::Result<HashSet<UpdatePath>> {

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+
+use futures::TryStreamExt;
+use sqlx::PgConnection;
+
+pub(crate) async fn list(conn: &mut PgConnection) -> anyhow::Result<()> {
+    let available_extensions = available_extensions(conn).await?;
+
+    for (extension, versions) in available_extensions {
+        println!("{extension}");
+        for version in versions {
+            println!("  {version}");
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(sqlx::FromRow)]
+struct ExtensionRow {
+    name: String,
+    version: String,
+}
+
+async fn available_extensions(
+    conn: &mut PgConnection,
+) -> anyhow::Result<HashMap<String, Vec<String>>> {
+    let mut rows = sqlx::query_as::<_, ExtensionRow>(
+        "select name, version from pgtle.available_extension_versions()",
+    )
+    .fetch(conn);
+
+    let mut available_extensions = HashMap::new();
+    while let Some(row) = rows.try_next().await? {
+        let versions: &mut Vec<String> = available_extensions.entry(row.name).or_default();
+        versions.push(row.version);
+    }
+
+    Ok(available_extensions)
+}

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -6,14 +6,22 @@ use sqlx::PgConnection;
 use crate::commands::install::update_paths;
 
 pub(crate) async fn list(conn: &mut PgConnection) -> anyhow::Result<()> {
+    let available_extension_versions = available_extensions_versions(conn).await?;
     let available_extensions = available_extensions(conn).await?;
 
-    for (extension_name, versions) in available_extensions {
+    for (extension_name, versions) in available_extension_versions {
+        let default_version = available_extensions.get(&extension_name);
+
         println!("{extension_name}");
         println!("  available versions:");
-        for version in versions {
-            println!("    {version}");
+        for version in &versions {
+            print!("    {version}");
+            if Some(version) == default_version {
+                print!(" (default)");
+            }
+            println!();
         }
+
         println!("  available update paths:");
         let update_paths = update_paths(conn, &extension_name).await?;
         if update_paths.is_empty() {
@@ -30,15 +38,15 @@ pub(crate) async fn list(conn: &mut PgConnection) -> anyhow::Result<()> {
 }
 
 #[derive(sqlx::FromRow)]
-struct ExtensionRow {
+struct AvailableExtensionVersion {
     name: String,
     version: String,
 }
 
-async fn available_extensions(
+async fn available_extensions_versions(
     conn: &mut PgConnection,
 ) -> anyhow::Result<HashMap<String, Vec<String>>> {
-    let mut rows = sqlx::query_as::<_, ExtensionRow>(
+    let mut rows = sqlx::query_as::<_, AvailableExtensionVersion>(
         "select name, version from pgtle.available_extension_versions()",
     )
     .fetch(conn);
@@ -50,4 +58,24 @@ async fn available_extensions(
     }
 
     Ok(available_extensions)
+}
+
+#[derive(sqlx::FromRow)]
+struct AvailableExtension {
+    name: String,
+    default_version: String,
+}
+
+async fn available_extensions(conn: &mut PgConnection) -> anyhow::Result<HashMap<String, String>> {
+    let mut rows = sqlx::query_as::<_, AvailableExtension>(
+        "select name, default_version from pgtle.available_extensions()",
+    )
+    .fetch(conn);
+
+    let mut extensions = HashMap::new();
+    while let Some(row) = rows.try_next().await? {
+        extensions.insert(row.name, row.default_version);
+    }
+
+    Ok(extensions)
 }

--- a/cli/src/commands/list.rs
+++ b/cli/src/commands/list.rs
@@ -3,14 +3,27 @@ use std::collections::HashMap;
 use futures::TryStreamExt;
 use sqlx::PgConnection;
 
+use crate::commands::install::update_paths;
+
 pub(crate) async fn list(conn: &mut PgConnection) -> anyhow::Result<()> {
     let available_extensions = available_extensions(conn).await?;
 
-    for (extension, versions) in available_extensions {
-        println!("{extension}");
+    for (extension_name, versions) in available_extensions {
+        println!("{extension_name}");
+        println!("  available versions:");
         for version in versions {
-            println!("  {version}");
+            println!("    {version}");
         }
+        println!("  available update paths:");
+        let update_paths = update_paths(conn, &extension_name).await?;
+        if update_paths.is_empty() {
+            println!("    None");
+        } else {
+            for update_path in update_paths {
+                println!("    from {} to {}", update_path.source, update_path.target);
+            }
+        }
+        println!();
     }
 
     Ok(())

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod install;
 pub mod login;
 pub mod publish;
 pub mod uninstall;
+pub mod list;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -62,6 +62,14 @@ enum Commands {
         #[arg(long)]
         registry_name: Option<String>,
     },
+
+    /// List available packages
+    #[clap(alias = "ls")]
+    List {
+        /// PostgreSQL connection string
+        #[arg(short, long)]
+        connection: String,
+    },
 }
 
 #[derive(Debug, clap::Args)]
@@ -137,6 +145,12 @@ async fn main() -> anyhow::Result<()> {
             config.get_registry(registry_name)?;
             commands::login::login(registry_name)?;
             println!("Login successful");
+            Ok(())
+        }
+
+        Commands::List { connection } => {
+            let mut conn = util::get_connection(connection).await?;
+            commands::list::list(&mut conn).await?;
             Ok(())
         }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

No way to find out about available extensions in a db using the CLI.

## What is the new behavior?

Users will be able to run `dbdev list --connection <connection string>` to see a list of available extensions. `dbdev ls` is an alias for `dbdev list`. Sample output looks like this:

```
raminder-hello_world
  available versions:
    0.0.1 (default)
  available update paths:
    None

olirice-asciiplot
  available versions:
    0.0.1 (default)
    0.0.2
  available update paths:
    from 0.0.1 to 0.0.2

supabase_test_helpers
  available versions:
    0.0.1 (default)
  available update paths:
    None

supabase-dbdev
  available versions:
    0.0.2
    0.0.3 (default)
  available update paths:
    None

raminder-function_vc
  available versions:
    1.0.0 (default)
    2.0.0
  available update paths:
    None

kiwicopple-countries
  available versions:
    0.0.1 (default)
    0.0.2
  available update paths:
    from 0.0.1 to 0.0.2
```

## Additional context

Fixes #141 
