### PR TITLE
bump version to 0.1.5

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "dbdev"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbdev"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["supabase"]
 

--- a/website/lib/types.ts
+++ b/website/lib/types.ts
@@ -24,6 +24,6 @@ export type NonNullableObject<T> = {
   [K in keyof T]: T[K] extends Array<infer U>
     ? Array<NonNullable<U>>
     : T[K] extends object
-    ? NonNullableObject<T[K]>
-    : NonNullable<T[K]>
+      ? NonNullableObject<T[K]>
+      : NonNullable<T[K]>
 }


### PR DESCRIPTION
To prepare for the next release of CLI with support for the `requires` key restrictions.