### PR TITLE
fix order of dropping & uninstalling supabase-dbdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Requires:
 */
 create extension if not exists http with schema extensions;
 create extension if not exists pg_tle;
-select pgtle.uninstall_extension_if_exists('supabase-dbdev');
 drop extension if exists "supabase-dbdev";
+select pgtle.uninstall_extension_if_exists('supabase-dbdev');
 select
     pgtle.install_extension(
         'supabase-dbdev',

--- a/docs/install-in-db-client.md
+++ b/docs/install-in-db-client.md
@@ -16,8 +16,8 @@ Run the following SQL to install the client:
 ```sql
 create extension if not exists http with schema extensions;
 create extension if not exists pg_tle;
-select pgtle.uninstall_extension_if_exists('supabase-dbdev');
 drop extension if exists "supabase-dbdev";
+select pgtle.uninstall_extension_if_exists('supabase-dbdev');
 select
     pgtle.install_extension(
         'supabase-dbdev',


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix/docs update

## What is the current behavior?

If `supabase-dbdev` extension was already installed and the SQL snippet to install it was run again, it failed on this statement `select pgtle.uninstall_extension_if_exists('supabase-dbdev');` with the following error:

```
ERROR:  cannot drop function "supabase-dbdev.control"() because other objects depend on it
DETAIL:  extension supabase-dbdev depends on function "supabase-dbdev.control"()
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
CONTEXT:  SQL statement "DROP FUNCTION "supabase-dbdev.control"()"
PL/pgSQL function uninstall_extension(text) line 22 at EXECUTE
SQL statement "SELECT pgtle.uninstall_extension(extname)"
PL/pgSQL function uninstall_extension_if_exists(text) line 3 at PERFORM
```

## What is the new behavior?

The `drop extension if exists "supabase-dbdev";` is now executed before to allow `pgtle.uninstall_extension...` to succeed.

## Additional context

N/A
