### PR TITLE
bump dbdev CLI version to 0.1.6

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "dbdev"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbdev"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["supabase"]
 


### PR DESCRIPTION
bump CLI version to prepare for next release.