### PR TITLE
fix broken migration

### DIFF
--- a/.github/workflows/pgTAP.yaml
+++ b/.github/workflows/pgTAP.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.88.0
+          version: 1.115.4
       - name: Supabase Start
         run: supabase start
       - name: Run Tests

--- a/.github/workflows/pgTAP.yaml
+++ b/.github/workflows/pgTAP.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.115.4
+          version: 1.127.4
       - name: Supabase Start
         run: supabase start
       - name: Run Tests

--- a/supabase/migrations/20230405083103_fix_auth_schema_values.sql
+++ b/supabase/migrations/20230405083103_fix_auth_schema_values.sql
@@ -11,6 +11,7 @@ set
 insert into
   auth.identities (
     id,
+    provider_id,
     provider,
     user_id,
     identity_data,
@@ -18,7 +19,8 @@ insert into
     updated_at
   )
 select
-  id,
+  gen_random_uuid(),
+  email,
   'email' as provider,
   id as user_id,
   jsonb_build_object('sub', id, 'email', email) as identity_data,

--- a/supabase/migrations/20240108072747_update_provider_id.sql
+++ b/supabase/migrations/20240108072747_update_provider_id.sql
@@ -1,0 +1,8 @@
+-- For email provider the provider_id should be the lowercase email
+-- which is availble in the email column
+-- This migration was necessecitated by a recent change in identities
+-- table schema by gotrue:
+-- https://github.com/supabase/gotrue/blob/master/migrations/20231117164230_add_id_pkey_identities.up.sql
+update auth.identities
+set provider_id = email
+where provider = 'email';


### PR DESCRIPTION
A recent change in the `auth.identities` table made the following changes:

1. The `id` column was renamed to `provider_id`.
2. A new `id` column which should be a random uuid.

This change broke our "fix_auth_schema_values" migration. To fix it we updated the insert statement to include email as the `provider_id` value and a random uuid as the `id`. Since for email provider the `provider_id` should be email id in lowercase we added a new migration "update_provider_id" to update the `provider_id` column to the `email` column value.

Updating an existing migration is bad practice but I don't think we have any other option now.