### PR TITLE
add a warning about not using dbdev with logical backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ dbdev is a package manager for Postgres [trusted language extensions (TLE)](http
 - Publish your own Extension: [supabase.github.io/dbdev/publish-extension/](https://supabase.github.io/dbdev/publish-extension/)
 - Read the dbdev [release blog post](https://supabase.com/blog/dbdev)
 
+### Warning
+
+Restoring a logical backup of a database with a TLE installed can fail. For this reason, dbdev should only be used with databases with physical backups enabled.
 ## Usage
 
 Users primarily interact with the registry using the dbdev SQL client. Once present, packages can be installed as follows:

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,7 @@ dbdev is a package manager for Postgres [trusted language extensions](https://gi
 If you want to publish your own TLE, you will need the dbdev CLI. Follow its [installation instructions](cli.md#installation) to get started.
 
 If you want to install an extension from the registry, you will need the SQL dbdev client. Follow its [installation instructions](https://database.dev/installer) to enable it in your database.
+
+!!! warning
+
+    Restoring a logical backup of a database with a TLE installed can fail. For this reason, dbdev should only be used with databases with physical backups enabled.


### PR DESCRIPTION
Adds a warning in README as well as on the docs' overview page about logical backups potentially failing with TLEs.

Fixes #178 