### PR TITLE
fix: redirect installer to docs installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ dbdev is a package manager for Postgres [trusted language extensions (TLE)](http
 ### Warning
 
 Restoring a logical backup of a database with a TLE installed can fail. For this reason, dbdev should only be used with databases with physical backups enabled.
+
 ## Usage
 
 Users primarily interact with the registry using the dbdev SQL client. Once present, packages can be installed as follows:

--- a/docs/install-in-db-client.md
+++ b/docs/install-in-db-client.md
@@ -11,6 +11,10 @@ Before you can install the dbdev extension into your database, ensure you have t
 
     If you database is running on Supabase, the above dependencies are already installed.
 
+!!! warning
+
+    Restoring a logical backup of a database with a TLE installed can fail. For this reason, dbdev should only be used with databases with physical backups enabled.
+
 Run the following SQL to install the client:
 
 ```sql

--- a/website/pages/installer.tsx
+++ b/website/pages/installer.tsx
@@ -8,8 +8,8 @@ const InstallerPage: NextPageWithLayout = () => {
 export async function getServerSideProps() {
   return {
     redirect: {
-      destination: '/supabase/dbdev',
-      permanent: true,
+      destination: 'https://supabase.github.io/dbdev/install-in-db-client',
+      permanent: false,
     },
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix

## What is the current behavior?

Instructions on https://database.dev/supabase/dbdev are outdated and not sure when the next release of `dbdev` is going out.

## What is the new behavior?

Redirect the `Getting Started` link to https://supabase.github.io/dbdev/install-in-db-client with up to date installation instructions.
