### PR TITLE
fix versions not visible for packages with new naming format

### DIFF
--- a/website/data/package-versions/package-versions-query.ts
+++ b/website/data/package-versions/package-versions-query.ts
@@ -41,7 +41,7 @@ export async function getPackageVersions(
     .from('package_versions')
     .select(SELECTED_COLUMNS.join(','))
     .or(
-      `package_name.eq.${handle}-${partialName},package_alias.eq.${handle}@${partialName}`
+      `package_name.eq.${handle}-${partialName},package_name.eq.${handle}@${partialName},package_alias.eq.${handle}@${partialName}`
     )
     .order('created_at', { ascending: false })
 

--- a/website/data/package-versions/package-versions-query.ts
+++ b/website/data/package-versions/package-versions-query.ts
@@ -41,7 +41,7 @@ export async function getPackageVersions(
     .from('package_versions')
     .select(SELECTED_COLUMNS.join(','))
     .or(
-      `package_name.eq.${handle}-${partialName},package_name.eq.${handle}@${partialName},package_alias.eq.${handle}@${partialName}`
+      `package_name.eq.${handle}@${partialName},package_alias.eq.${handle}@${partialName}`
     )
     .order('created_at', { ascending: false })
 


### PR DESCRIPTION
Versions on a package's version tab in UI were not visible for a package with the new `user@package` naming format. 