### PR TITLE
bump macos runner version to 15

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -122,7 +122,7 @@ jobs:
     name: Release Artifacts on macOS
     needs:
       - create-release
-    runs-on: macos-12
+    runs-on: macos-15
     timeout-minutes: 45
     steps:
       - name: Install Rust Toolchain


### PR DESCRIPTION
Macos 12 runner is no longer supported by Github. Bumped runner version to latest.