### PR TITLE
fix macos package name

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -146,7 +146,7 @@ jobs:
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz
-          asset_name: dbdev-${{ github.ref_name }}-macos-amd64.tar.gz
+          asset_name: dbdev-${{ github.ref_name }}-macos-arm64.tar.gz
           asset_content_type: application/${{ matrix.box.content-type }}
 
   build-windows:

--- a/.github/workflows/release-homebrew-tap.yaml
+++ b/.github/workflows/release-homebrew-tap.yaml
@@ -44,17 +44,17 @@ jobs:
           tag: ${{ inputs.tag }}
           fileName: "dbdev-${{ inputs.tag }}-linux-arm64.tar.gz"
 
-      - name: Download macOS AMD64 package
+      - name: Download macOS ARM64 package
         uses: robinraju/release-downloader@v1.12
         with:
           repository: "supabase/dbdev"
           tag: ${{ inputs.tag }}
-          fileName: "dbdev-${{ inputs.tag }}-macos-amd64.tar.gz"
+          fileName: "dbdev-${{ inputs.tag }}-macos-arm64.tar.gz"
       - name: Generate Manifest File
         run: |
           linux_amd64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-linux-amd64.tar.gz | cut -d" " -f1`
           linux_arm64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-linux-arm64.tar.gz | cut -d" " -f1`
-          macos_amd64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-macos-amd64.tar.gz | cut -d" " -f1`
+          macos_arm64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-macos-arm64.tar.gz | cut -d" " -f1`
 
           version="${{ steps.vars.outputs.version }}"
 
@@ -70,16 +70,16 @@ jobs:
           echo '' >> dbdev.rb
           echo '  on_macos do' >> dbdev.rb
           echo '    if Hardware::CPU.arm?' >> dbdev.rb
-          echo "      url \"https://github.com/supabase/dbdev/releases/download/v${version}/dbdev-v${version}-macos-amd64.tar.gz\"" >> dbdev.rb
-          echo "      sha256 \"${macos_amd64_hash}\"" >> dbdev.rb
+          echo "      url \"https://github.com/supabase/dbdev/releases/download/v${version}/dbdev-v${version}-macos-arm64.tar.gz\"" >> dbdev.rb
+          echo "      sha256 \"${macos_arm64_hash}\"" >> dbdev.rb
           echo '' >> dbdev.rb
           echo '      def install' >> dbdev.rb
           echo '        bin.install "dbdev"' >> dbdev.rb
           echo '      end' >> dbdev.rb
           echo '    end' >> dbdev.rb
           echo '    if Hardware::CPU.intel?' >> dbdev.rb
-          echo "      url \"https://github.com/supabase/dbdev/releases/download/v${version}/dbdev-v${version}-macos-amd64.tar.gz\"" >> dbdev.rb
-          echo "      sha256 \"${macos_amd64_hash}\"" >> dbdev.rb
+          echo "      url \"https://github.com/supabase/dbdev/releases/download/v${version}/dbdev-v${version}-macos-arm64.tar.gz\"" >> dbdev.rb
+          echo "      sha256 \"${macos_arm64_hash}\"" >> dbdev.rb
           echo '' >> dbdev.rb
           echo '      def install' >> dbdev.rb
           echo '        bin.install "dbdev"' >> dbdev.rb


### PR DESCRIPTION
The package names for MacOS arm64 were incorrectly named as amd64.

Fixes #290 