### PR TITLE
chore: bump supabase cli to latest in pgTAP tests CI

### DIFF
--- a/.github/workflows/pgTAP.yaml
+++ b/.github/workflows/pgTAP.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.127.4
+          version: 2.75.0
       - name: Supabase Start
         run: supabase start
       - name: Run Tests


### PR DESCRIPTION
Needed to fix failing tests in CI. E.g. https://github.com/supabase/dbdev/actions/runs/22055831019/job/63723507734?pr=368