### PR TITLE
fix: generate short-lived token to create PRs in homebrew and scoop repos

### DIFF
--- a/.github/workflows/manual-release-brew-and-scoop.yaml
+++ b/.github/workflows/manual-release-brew-and-scoop.yaml
@@ -15,12 +15,10 @@ jobs:
     uses: ./.github/workflows/release-homebrew-tap.yaml
     with:
       tag: ${{ github.event.inputs.tag }}
-    secrets:
-      homebrew_tap_rw: ${{ secrets.HOMEBREW_TAP_RW }}
+    secrets: inherit
 
   call-release-scoop-bucket:
     uses: ./.github/workflows/release-scoop-bucket.yaml
     with:
       tag: ${{ github.event.inputs.tag }}
-    secrets:
-      scoop_bucket_rw: ${{ secrets.SCOOP_BUCKET_RW }}
+    secrets: inherit

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -186,3 +186,20 @@ jobs:
           asset_path: ./cli/target/release/dbdev.zip
           asset_name: dbdev-${{ github.ref_name }}-windows-amd64.zip
           asset_content_type: application/zip
+
+  release-homebrew-tap:
+    needs:
+      - build-linux
+      - build-macos
+    uses: ./.github/workflows/release-homebrew-tap.yaml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit
+
+  release-scoop-bucket:
+    needs:
+      - build-windows
+    uses: ./.github/workflows/release-scoop-bucket.yaml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/release-homebrew-tap.yaml
+++ b/.github/workflows/release-homebrew-tap.yaml
@@ -6,9 +6,6 @@ on:
       tag:
         required: true
         type: string
-    secrets:
-      homebrew_tap_rw:
-        required: true
 
 permissions:
   contents: write
@@ -17,12 +14,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: supabase
+          repositories: homebrew-tap
+
+      - name: Checkout homebrew-tap repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: supabase/homebrew-tap
           ref: "main"
-          token: ${{ secrets.homebrew_tap_rw }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+
       - name: Compute tag and version
         id: vars
         run: |
@@ -30,6 +38,7 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           # strip the leading v (if present)
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
       - name: Download Linux AMD64 package
         uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1
         with:
@@ -50,6 +59,7 @@ jobs:
           repository: "supabase/dbdev"
           tag: ${{ inputs.tag }}
           fileName: "dbdev-${{ inputs.tag }}-macos-arm64.tar.gz"
+
       - name: Generate Manifest File
         run: |
           linux_amd64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-linux-amd64.tar.gz | cut -d" " -f1`
@@ -115,7 +125,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.homebrew_tap_rw }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Release dbdev version v${{ steps.vars.outputs.version }}"
           title: "Release dbdev version v${{ steps.vars.outputs.version }}"
           body-path: PR_BODY.md

--- a/.github/workflows/release-scoop-bucket.yaml
+++ b/.github/workflows/release-scoop-bucket.yaml
@@ -6,9 +6,6 @@ on:
       tag:
         required: true
         type: string
-    secrets:
-      scoop_bucket_rw:
-        required: true
 
 permissions:
   contents: write
@@ -17,11 +14,21 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: supabase
+          repositories: scoop-bucket
+
+      - name: Checkout scoop-bucket repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: supabase/scoop-bucket
           ref: "main"
-          token: ${{ secrets.scoop_bucket_rw }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Compute tag and version
@@ -71,7 +78,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.scoop_bucket_rw }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Release dbdev version v${{ steps.vars.outputs.version }}"
           title: "Release dbdev version v${{ steps.vars.outputs.version }}"
           body-path: PR_BODY.md


### PR DESCRIPTION
We now generate a short-lived token to generate the PRs in `supabase/homebrew-tap` and `supabase/scoop-bucket` repositories. Also the homebrew and scoop releases are now triggerred automatically when a tag is pushed.