### PR TITLE
fix: GH_APP_CLIENT_ID is a secret not a var

### DIFF
--- a/.github/workflows/release-homebrew-tap.yaml
+++ b/.github/workflows/release-homebrew-tap.yaml
@@ -18,7 +18,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: supabase
           repositories: homebrew-tap

--- a/.github/workflows/release-scoop-bucket.yaml
+++ b/.github/workflows/release-scoop-bucket.yaml
@@ -18,7 +18,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: supabase
           repositories: scoop-bucket


### PR DESCRIPTION
Also `app-id` is deprecated in favour of `client-id` in the `actions/create-github-app-token` action.