### PR TITLE
Ci: Fix macos build releases

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -129,7 +129,10 @@ jobs:
     name: Release Artifacts on macOS
     needs:
       - create-release
-    runs-on: macos-15
+    strategy:
+      matrix:
+        os: [macos-15-intel, macos-15]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
       - name: Install Rust Toolchain
@@ -153,7 +156,7 @@ jobs:
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz
-          asset_name: dbdev-${{ github.ref_name }}-macos-arm64.tar.gz
+          asset_name: dbdev-${{ github.ref_name }}-macos-${{ runner.arch == 'X64' && 'amd64' || 'arm64' }}.tar.gz
           asset_content_type: application/${{ matrix.box.content-type }}
 
   build-windows:

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -157,7 +157,7 @@ jobs:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./cli/target/release/dbdev.tar.gz
           asset_name: dbdev-${{ github.ref_name }}-macos-${{ runner.arch == 'X64' && 'amd64' || 'arm64' }}.tar.gz
-          asset_content_type: application/${{ matrix.box.content-type }}
+          asset_content_type: application/gzip
 
   build-windows:
     name: Release Artifacts on Windows

--- a/.github/workflows/release-homebrew-tap.yaml
+++ b/.github/workflows/release-homebrew-tap.yaml
@@ -60,11 +60,19 @@ jobs:
           tag: ${{ inputs.tag }}
           fileName: "dbdev-${{ inputs.tag }}-macos-arm64.tar.gz"
 
+      - name: Download macOS AMD64 package
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1
+        with:
+          repository: "supabase/dbdev"
+          tag: ${{ inputs.tag }}
+          fileName: "dbdev-${{ inputs.tag }}-macos-amd64.tar.gz"
+
       - name: Generate Manifest File
         run: |
           linux_amd64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-linux-amd64.tar.gz | cut -d" " -f1`
           linux_arm64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-linux-arm64.tar.gz | cut -d" " -f1`
           macos_arm64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-macos-arm64.tar.gz | cut -d" " -f1`
+          macos_amd64_hash=`shasum -a 256 dbdev-${{ inputs.tag }}-macos-amd64.tar.gz | cut -d" " -f1`
 
           version="${{ steps.vars.outputs.version }}"
 
@@ -88,8 +96,8 @@ jobs:
           echo '      end' >> dbdev.rb
           echo '    end' >> dbdev.rb
           echo '    if Hardware::CPU.intel?' >> dbdev.rb
-          echo "      url \"https://github.com/supabase/dbdev/releases/download/v${version}/dbdev-v${version}-macos-arm64.tar.gz\"" >> dbdev.rb
-          echo "      sha256 \"${macos_arm64_hash}\"" >> dbdev.rb
+          echo "      url \"https://github.com/supabase/dbdev/releases/download/v${version}/dbdev-v${version}-macos-amd64.tar.gz\"" >> dbdev.rb
+          echo "      sha256 \"${macos_amd64_hash}\"" >> dbdev.rb
           echo '' >> dbdev.rb
           echo '      def install' >> dbdev.rb
           echo '        bin.install "dbdev"' >> dbdev.rb


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Updates the release workflow to generate correct artifacts for both amd64 and arm64 macOS CPUs
- Updates the Homebrew formula logic to dynamically pull the correct binary for macOS amd64/intel CPU.


## What is the current behavior?

#290

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

