### PR TITLE
docs: add dbdev install and list examples

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -10,10 +10,16 @@ Once the `dbdev` TLE is installed
 select dbdev.install('math', '0.0.1');
 ```
 
-Where the `dbdev` CLI functions as a backup solution for installing packages when requirements for the `dbdev` TLE are not met (no [pgsql-http](https://github.com/pramsey/pgsql-http))
+Where the `dbdev` CLI functions as a backup solution for installing local packages when requirements for the `dbdev` TLE are not met (no [pgsql-http](https://github.com/pramsey/pgsql-http))
 
 ```
-dbdev install --connection 'postgresql://...' --package 'math' --version '0.0.1'
+dbdev install --connection 'postgresql://...' path --directory ./math
+```
+
+To list package versions installed into `pg_tle` and available to enable with `CREATE EXTENSION`, run:
+
+```
+dbdev list --connection 'postgresql://...'
 ```
 
 ## Objective Statements
@@ -37,6 +43,7 @@ Usage: dbdev [OPTIONS] <COMMAND>
 
 Commands:
   install    Install a package to a database
+  list       List available packages
   uninstall  Uninstall a package from a database
   help       Print this message or the help of the given subcommand(s)
 
@@ -55,13 +62,39 @@ Options:
 ```
 Install a package to a database
 
-Usage: dbdev install [OPTIONS] --connection <CONNECTION>
+Usage: dbdev install [OPTIONS] --connection <CONNECTION> <SOURCE>
 
 Options:
   -c, --connection <CONNECTION>  PostgreSQL connection string
-  -p, --package <PACKAGE>        Package name on package index
-      --path <PATH>              From local directory
   -h, --help                     Print help
+
+Sources:
+  path     From a local directory
+```
+
+For example, to install a package from a local directory:
+
+```
+dbdev install --connection 'postgresql://postgres:postgres@localhost:54322/postgres' path --directory ./pg_idkit
+```
+
+### list
+
+```
+List available packages
+
+Usage: dbdev list --connection <CONNECTION>
+
+Options:
+  -c, --connection <CONNECTION>  PostgreSQL connection string
+  -h, --help                     Print help
+```
+
+You can query the same extension names and default versions directly from PostgreSQL:
+
+```sql
+select name, default_version
+from pgtle.available_extensions();
 ```
 
 ### uninstall

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,7 +16,7 @@ Where the `dbdev` CLI functions as a backup solution for installing local packag
 dbdev install --connection 'postgresql://...' path --directory ./math
 ```
 
-To list package versions installed into `pg_tle` and available to enable with `CREATE EXTENSION`, run:
+To list package versions installed into `pg_tle` and available to enable with `create extension`, run:
 
 ```
 dbdev list --connection 'postgresql://...'
@@ -88,13 +88,6 @@ Usage: dbdev list --connection <CONNECTION>
 Options:
   -c, --connection <CONNECTION>  PostgreSQL connection string
   -h, --help                     Print help
-```
-
-You can query the same extension names and default versions directly from PostgreSQL:
-
-```sql
-select name, default_version
-from pgtle.available_extensions();
 ```
 
 ### uninstall

--- a/website/content/docs/cli.mdx
+++ b/website/content/docs/cli.mdx
@@ -102,4 +102,31 @@ Alternatively, you can build the binary from source. You will need to have [Rust
 
 If you have [cargo-install](https://doc.rust-lang.org/cargo/commands/cargo-install.html), you can perform all the above steps with a single command: `cargo install --git https://github.com/supabase/dbdev.git dbdev`.
 
+## Common commands
+
+### Install a local package
+
+Use `dbdev install` to install a local TLE package into the connected database:
+
+```bash
+dbdev install --connection "postgresql://postgres:postgres@localhost:54322/postgres" path --directory ./pg_idkit
+```
+
+The `path` source defaults to the current directory when `--directory` is omitted.
+
+### List installed package versions
+
+Use `dbdev list` to list package versions installed into `pg_tle` and available to enable with `CREATE EXTENSION`:
+
+```bash
+dbdev list --connection "postgresql://postgres:postgres@localhost:54322/postgres"
+```
+
+You can query the same extension names and default versions directly from PostgreSQL:
+
+```sql
+select name, default_version
+from pgtle.available_extensions();
+```
+
 Now you're ready to [publish your first package](/docs/publish-extension).

--- a/website/content/docs/cli.mdx
+++ b/website/content/docs/cli.mdx
@@ -102,9 +102,13 @@ Alternatively, you can build the binary from source. You will need to have [Rust
 
 If you have [cargo-install](https://doc.rust-lang.org/cargo/commands/cargo-install.html), you can perform all the above steps with a single command: `cargo install --git https://github.com/supabase/dbdev.git dbdev`.
 
-## Common commands
+Now you're ready to [publish your first package](/docs/publish-extension).
 
-### Install a local package
+## Developer Commands
+
+If you are developing a package locally, the following dbdev commands will be useful.
+
+### Install a Local Package
 
 Use `dbdev install` to install a local TLE package into the connected database:
 
@@ -114,19 +118,10 @@ dbdev install --connection "postgresql://postgres:postgres@localhost:54322/postg
 
 The `path` source defaults to the current directory when `--directory` is omitted.
 
-### List installed package versions
+### List Installed Package Versions
 
 Use `dbdev list` to list package versions installed into `pg_tle` and available to enable with `CREATE EXTENSION`:
 
 ```bash
 dbdev list --connection "postgresql://postgres:postgres@localhost:54322/postgres"
 ```
-
-You can query the same extension names and default versions directly from PostgreSQL:
-
-```sql
-select name, default_version
-from pgtle.available_extensions();
-```
-
-Now you're ready to [publish your first package](/docs/publish-extension).


### PR DESCRIPTION
## Summary
- document installing a local TLE package with `dbdev install`
- document listing installed package versions with `dbdev list`
- include the equivalent `pgtle.available_extensions()` SQL query

Fixes #134.
Fixes #197.

## Test plan
- `git diff --check`