### PR TITLE
fix: add readonly permissions to workflow

### DIFF
--- a/.github/workflows/website-tests.yaml
+++ b/.github/workflows/website-tests.yaml
@@ -12,6 +12,9 @@ on:
       - "website/**"
       - ".github/workflows/website-tests.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test & Coverage


### PR DESCRIPTION
Fix for [https://github.com/supabase/dbdev/security/code-scanning/1](https://github.com/supabase/dbdev/security/code-scanning/1)

Add an explicit `permissions` block to the workflow to enforce least privilege for `GITHUB_TOKEN`.